### PR TITLE
change travis.yml to deploy docs to github page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,19 @@ smalltalk:
 - Pharo64-7.0
 - Pharo-7.0
 - Pharo-6.1
+
 matrix:
+  include:
+    - language: node_js
+      node_js: '8'
+      cache:
+        yarn: true
+      script:
+        - git config --global user.name "${GH_NAME}"
+        - git config --global user.email "${GH_EMAIL}"
+        - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
+        - cd website && yarn install && GIT_USER="${GH_NAME}" yarn run publish-gh-pages
+        
   allow_failures:
   - smalltalk: Pharo64-7.0
   - smalltalk: Pharo-7.0


### PR DESCRIPTION
Para que esto funione se tiene que:
* Agregar en el travis las siguientes variables:
  * GH_NAME
  * GH_EMAIL
  * GH_TOKEN
* En github Ir a la configuracion del repositorio y agregar la github page.

(No encontre forma de hacer el deploy de la documentacion solo cuando se realiza un push a master)