### PR TITLE
Let AssertionChecker as the entry point for using the library

### DIFF
--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -12,7 +12,7 @@ jobs:
         load-spec: [ deployment, dependent-sunit-extensions, tests, tools, development ]
     name: ${{ matrix.smalltalk }} + ${{ matrix.load-spec }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
         smalltalk: [ Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
     name: ${{ matrix.smalltalk }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
@@ -23,3 +23,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: Unit-Tests-${{matrix.smalltalk}}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Quick links
 - Additional Math abstractions
 - Bindings and Optionals
 - Exception Handling extensions
-- Metaprogramming
+- Meta-programming
 - SUnit extensions
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ understanding over specific topics:
   required values, that can be unknown at the beginning of an execution.
   See the [related documentation.](reference/BindingsAndOptionals.md)
 - **Exception Handling**: Extensions to the [exception handling mechanics](reference/ExceptionHandling.md).
-- **Metaprogramming**: Some abstractions like [namespaces](reference/Namespaces.md)
+- **Meta-programming**: Some abstractions like [namespaces](reference/Namespaces.md)
 and [interfaces](reference/Interfaces.md).
 - **SUnit**: [Extensions to the SUnit framework](reference/SUnit.md).
 

--- a/docs/reference/Collections.md
+++ b/docs/reference/Collections.md
@@ -84,7 +84,7 @@ iterator next "$b".
 
 ## Ordered Set
 
-An `OrderderSet` is a set preserving the element's insertion order. It complies
+An `OrderedSet` is a set preserving the element's insertion order. It complies
 with the sequenceable collection protocol.
 
 ```smalltalk

--- a/docs/reference/Comparison.md
+++ b/docs/reference/Comparison.md
@@ -17,7 +17,7 @@ It will apply the combinator operator to each one of the objects:
   collection and then combine them.
 - `combineHashOf:with:` will send the hash message to the two objects and then
   combine them.
-- `combineAll::` expectes a collection of hashes and will combine them.
+- `combineAll::` expects a collection of hashes and will combine them.
 - `combine:with:` will combine two hash values
 
 ### Hash Combinator Examples
@@ -42,7 +42,7 @@ Equality checkers always performs a `==` comparison first and proceed with the
 rest of the rules only if the objects are not identical.
 
 By default `equalityChecker` is an instance of `PropertyBasedEqualityChecker`
-and it alredy knowns the receiving instance. It can be configured with:
+and it already knowns the receiving instance. It can be configured with:
 
 - `compare: selector` will add a rule to the checker that sends the provided
   message on the receiver and target object and compare the results by `=`

--- a/docs/tutorial/Assertions.md
+++ b/docs/tutorial/Assertions.md
@@ -37,42 +37,39 @@ a valid code consists only of letters. So let's rewrite our example:
 
 code := 'AR'.
 
-AssertionCheckerBuilder new
-  checking: [ :asserter |
+AssertionChecker
+  check: [ :asserter |
     asserter
       enforce: [ code size = 2 ]
       because: 'ISO 3166-1 Alpha-2 codes must have exactly two letters';
       enforce: [ code allSatisfy: #isLetter ]
       because: 'ISO 3166-1 Alpha-2 codes must only contain letters'
-    ];
-  buildAndCheck
+    ]
 ```
 
-Note that in this case we are creating an `AssertionCheckerBuilder` and
-configuring all the conditions to enforce. Let's try now replacing `code` with
-`'AR3'` and `Do it` again. By default all the conditions to enforce are checked
-so you should get an error message combining both explanations, and if you
-handle the raised exception you can get all the failures by sending it the
-message `failures`.
+Note that in this case we are configuring all the conditions to enforce. Let's
+try now replacing `code` with `'AR3'` and `Do it` again. By default all the
+conditions to enforce are checked so you should get an error message combining
+both explanations, and if you handle the raised exception you can get all the
+failures by sending it the message `failures`.
 
 If you want the more usual behavior of stopping after the first failure you can
-configure the builder to fail fast:
+configure it to fail fast:
 
 ```smalltalk
 | code |
 
 code := 'AR3'.
 
-AssertionCheckerBuilder new
-  failFast;
-  checking: [ :asserter |
+AssertionChecker
+  check: [ :asserter |
     asserter
       enforce: [ code size = 2 ]
       because: 'ISO 3166-1 Alpha-2 codes must have exactly two letters';
       enforce: [ code allSatisfy: #isLetter ]
       because: 'ISO 3166-1 Alpha-2 codes must only contain letters'
-    ];
-  buildAndCheck
+    ]
+  configuredBy: [ :checker | checker failFast ]
 ```
 
 If you `Do it` you will get only the first failure, the next conditions won't
@@ -90,19 +87,18 @@ valid code. Now we will consider only the officially assigned codes as valid:
 code := 'AA'.
 officiallyAssignedCodes := #('AR' 'BR' 'US').
 
-AssertionCheckerBuilder new
-  checking: [ :asserter |
+AssertionChecker
+  check: [ :asserter |
     asserter
       enforce: [ code size = 2 and: [ code allSatisfy: #isLetter ]]
       because: 'ISO 3166-1 Alpha-2 codes must have exactly two letters'
-      onSuccess: [ :sucessAsserter |
-        sucessAsserter
+      onSuccess: [ :successAsserter |
+        successAsserter
           enforce: [ officiallyAssignedCodes includes: code ]
           because: [ '<1s> is not an officially assigned code'
             expandMacrosWith: code ]
         ]
-    ];
-    buildAndCheck
+    ]
 ```
 
 Here we are introducing two new features:
@@ -112,8 +108,7 @@ Here we are introducing two new features:
   is satisfied. So we can make assumptions about what `code` looks like at this point.
 - Second, using a block as the `because:` argument. This avoids creating
   unnecessary objects because the explanation will only be evaluated if the
-  condition is not met. In this case the argument is a literal String, so it
-  makes no difference.
+  condition is not met.
 
 ## Refusing
 
@@ -126,18 +121,17 @@ Sometimes it's easier to explain a condition using negative logic, so
 code := 'AR'.
 unassignedCodes := #('LO' 'LP' 'OU').
 
-AssertionCheckerBuilder new
-  checking: [ :asserter |
+AssertionChecker
+  check: [ :asserter |
     asserter
       enforce: [ code size = 2 and: [ code allSatisfy: #isLetter ]]
       because: 'ISO 3166-1 Alpha-2 codes must have exactly two letters'
-      onSuccess: [ :sucessAsserter |
-        sucessAsserter
+      onSuccess: [ :successAsserter |
+        successAsserter
           refuse: [ unassignedCodes includes: code ]
           because: [ '<1s> is an unassigned code' expandMacrosWith: code ]
         ]
-    ];
-    buildAndCheck
+    ]
 ```
 
 ## Configuring the error to raise
@@ -145,7 +139,7 @@ AssertionCheckerBuilder new
 If not specified the library will raise `AssertionFailed` when some check fails.
 If you want to raise a different kind of error there are two ways to configure it:
 
-For single condition checks you can use `enforce:because:raising:` or `refuse:because:raising:`.
+For single condition checks, use `enforce:because:raising:` or `refuse:because:raising:`
 
 ```smalltalk
 | code |
@@ -158,24 +152,25 @@ AssertionChecker
   raising: Error
 ```
 
-When using the builder you should use:
+For multiple condition checks, use:
 
 ```smalltalk
 | code |
 
 code := 'AR'.
 
-AssertionCheckerBuilder new
-  raising: InstanceCreationFailed;
-  checking: [ :asserter |
+AssertionChecker
+  check: [ :asserter |
     asserter
       enforce: [ code size = 2 ]
       because: 'ISO 3166-1 Alpha-2 codes must have exactly two letters';
       enforce: [ code allSatisfy: #isLetter ]
       because: 'ISO 3166-1 Alpha-2 codes must only contain letters'
-    ];
-  buildAndCheck
+  ]
+  configuredBy: [ :checker |
+    checker raising: InstanceCreationFailed
+  ]
 ```
 
-but keep in mind when using the builder that the error to raise must understand
+but keep in mind when multiple conditions, that the error to raise must understand
 `signalAll:` in order to work.

--- a/docs/tutorial/Assertions.md
+++ b/docs/tutorial/Assertions.md
@@ -172,5 +172,5 @@ AssertionChecker
   ]
 ```
 
-but keep in mind when multiple conditions, that the error to raise must understand
+but keep in mind when using multiple conditions, that the error to raise must understand
 `signalAll:` in order to work.

--- a/source/Buoy-Assertions-Tests/AssertionCheckerBuilderTest.class.st
+++ b/source/Buoy-Assertions-Tests/AssertionCheckerBuilderTest.class.st
@@ -4,17 +4,8 @@ I'm a test case for Assertion Checker Builder
 Class {
 	#name : #AssertionCheckerBuilderTest,
 	#superclass : #TestCase,
-	#instVars : [
-		'checkerBuilder'
-	],
-	#category : 'Buoy-Assertions-Tests'
+	#category : #'Buoy-Assertions-Tests'
 }
-
-{ #category : #initialization }
-AssertionCheckerBuilderTest >> setUp [
-
-	checkerBuilder := AssertionCheckerBuilder new
-]
 
 { #category : #tests }
 AssertionCheckerBuilderTest >> testConditionalChecking [
@@ -24,16 +15,22 @@ AssertionCheckerBuilderTest >> testConditionalChecking [
 	explanation := 'A row count must be positive'.
 	rowCount := -15.
 
-	checkerBuilder
-		checking: [ :asserter | asserter refuse: [ rowCount isNil ] because: [ self fail ] onSuccess: [ :successAsserter | successAsserter enforce: [ rowCount positive ] because: [ explanation ] ] ].
-
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker check: [ :asserter |
+				asserter
+					refuse: [ rowCount isNil ]
+					because: [ self fail ]
+					onSuccess: [ :successAsserter |
+					successAsserter enforce: [ rowCount positive ] because: [ explanation ] ]
+				]
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: explanation;
-				assertCollection: exception failures hasSameElements: {explanation} ]
+				assertCollection: exception failures hasSameElements: { explanation }
+			]
 ]
 
 { #category : #tests }
@@ -44,15 +41,22 @@ AssertionCheckerBuilderTest >> testConditionalCheckingWhenFirstConditionFails [
 	explanation := 'A row count must be positive'.
 	rowCount := -15.
 
-	checkerBuilder checking: [ :asserter | asserter enforce: [ rowCount positive ] because: explanation onSuccess: [ :successAsserter | self fail ] ].
 
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker check: [ :asserter |
+				asserter
+					enforce: [ rowCount positive ]
+					because: explanation
+					onSuccess: [ :successAsserter | self fail ]
+				]
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: explanation;
-				assertCollection: exception failures hasSameElements: {explanation} ]
+				assertCollection: exception failures hasSameElements: { explanation }
+			]
 ]
 
 { #category : #tests }
@@ -61,21 +65,24 @@ AssertionCheckerBuilderTest >> testFailFast [
 	| mathFailureExplanation |
 
 	mathFailureExplanation := 'An obvious math error'.
-	checkerBuilder
-		failFast;
-		checking: [ :asserter | 
-			asserter
-				enforce: [ 2 > 3 ] because: mathFailureExplanation;
-				enforce: [ self fail ] because: [ self fail ];
-				enforce: [ self fail ] because: [ self fail ] ].
 
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker
+				check: [ :asserter |
+					asserter
+						enforce: [ 2 > 3 ] because: mathFailureExplanation;
+						enforce: [ self fail ] because: [ self fail ];
+						enforce: [ self fail ] because: [ self fail ]
+					]
+				configuredBy: #failFast
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: mathFailureExplanation;
-				assertCollection: exception failures hasSameElements: {mathFailureExplanation} ]
+				assertCollection: exception failures hasSameElements: { mathFailureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -84,22 +91,28 @@ AssertionCheckerBuilderTest >> testFailFastConfiguringErrorToRaise [
 	| mathFailureExplanation |
 
 	mathFailureExplanation := 'An obvious math error'.
-	checkerBuilder
-		failFast;
-		raising: InstanceCreationFailed;
-		checking: [ :asserter | 
-			asserter
-				enforce: [ 2 > 3 ] because: mathFailureExplanation;
-				enforce: [ self fail ] because: [ self fail ];
-				enforce: [ self fail ] because: [ self fail ] ].
 
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker
+				check: [ :asserter |
+					asserter
+						enforce: [ 2 > 3 ] because: mathFailureExplanation;
+						enforce: [ self fail ] because: [ self fail ];
+						enforce: [ self fail ] because: [ self fail ]
+					]
+				configuredBy: [ :checker |
+					checker
+						failFast;
+						raising: InstanceCreationFailed
+					]
+			]
 		raise: InstanceCreationFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: mathFailureExplanation;
-				assertCollection: exception failures hasSameElements: {mathFailureExplanation} ]
+				assertCollection: exception failures hasSameElements: { mathFailureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -108,21 +121,27 @@ AssertionCheckerBuilderTest >> testFailFastInConditional [
 	| mathFailureExplanation |
 
 	mathFailureExplanation := 'An obvious math error'.
-	checkerBuilder
-		failFast;
-		checking: [ :asserter | 
-			asserter
-				enforce: [ true ] because: [ self fail ] onSuccess: [ :successAsserter | successAsserter enforce: [ false ] because: mathFailureExplanation ];
-				enforce: [ self fail ] because: [ self fail ];
-				enforce: [ self fail ] because: [ self fail ] ].
 
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker
+				check: [ :asserter |
+					asserter
+						enforce: [ true ]
+						because: [ self fail ]
+						onSuccess: [ :successAsserter |
+							successAsserter enforce: [ false ] because: mathFailureExplanation ];
+						enforce: [ self fail ] because: [ self fail ];
+						enforce: [ self fail ] because: [ self fail ]
+					]
+				configuredBy: #failFast
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: mathFailureExplanation;
-				assertCollection: exception failures hasSameElements: {mathFailureExplanation} ]
+				assertCollection: exception failures hasSameElements: { mathFailureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -131,21 +150,24 @@ AssertionCheckerBuilderTest >> testFailFastPassingSomeConditions [
 	| failureExplanation |
 
 	failureExplanation := 'An obvious math error'.
-	checkerBuilder
-		failFast;
-		checking: [ :asserter | 
-			asserter
-				enforce: [ true ] because: [ self fail ];
-				enforce: [ false ] because: failureExplanation;
-				enforce: [ self fail ] because: [ self fail ] ].
 
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker
+				check: [ :asserter |
+					asserter
+						enforce: [ true ] because: [ self fail ];
+						enforce: [ false ] because: failureExplanation;
+						enforce: [ self fail ] because: [ self fail ]
+					]
+				configuredBy: #failFast
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: failureExplanation;
-				assertCollection: exception failures hasSameElements: {failureExplanation} ]
+				assertCollection: exception failures hasSameElements: { failureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -154,19 +176,21 @@ AssertionCheckerBuilderTest >> testSeveralConditionsButOnlyOneFailed [
 	| mathFailureExplanation |
 
 	mathFailureExplanation := 'An obvious math error'.
-	checkerBuilder
-		checking: [ :asserter | 
-			asserter
-				enforce: [ 4 > 3 ] because: [ self fail ];
-				enforce: [ 1 > 2 ] because: mathFailureExplanation;
-				refuse: [ #() notEmpty ] because: [ self fail ] ].
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker check: [ :asserter |
+				asserter
+					enforce: [ 4 > 3 ] because: [ self fail ];
+					enforce: [ 1 > 2 ] because: mathFailureExplanation;
+					refuse: [ #(  ) notEmpty ] because: [ self fail ]
+				]
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: mathFailureExplanation;
-				assertCollection: exception failures hasSameElements: {mathFailureExplanation} ]
+				assertCollection: exception failures hasSameElements: { mathFailureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -175,20 +199,24 @@ AssertionCheckerBuilderTest >> testSeveralConditionsButOnlyOneFailedConfiguringE
 	| mathFailureExplanation |
 
 	mathFailureExplanation := 'An obvious math error'.
-	checkerBuilder
-		raising: InstanceCreationFailed;
-		checking: [ :asserter | 
-			asserter
-				enforce: [ 4 > 3 ] because: [ self fail ];
-				enforce: [ 1 > 2 ] because: mathFailureExplanation;
-				enforce: [ #() isEmpty ] because: [ self fail ] ].
+
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker
+				check: [ :asserter |
+					asserter
+						enforce: [ 4 > 3 ] because: [ self fail ];
+						enforce: [ 1 > 2 ] because: mathFailureExplanation;
+						enforce: [ #(  ) isEmpty ] because: [ self fail ]
+					]
+				configuredBy: [ :checker | checker raising: InstanceCreationFailed ]
+			]
 		raise: InstanceCreationFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: mathFailureExplanation;
-				assertCollection: exception failures hasSameElements: {mathFailureExplanation} ]
+				assertCollection: exception failures hasSameElements: { mathFailureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -198,21 +226,23 @@ AssertionCheckerBuilderTest >> testSeveralConditionsFailed [
 
 	mathFailureExplanation := 'An obvious math error'.
 	collectionSizeFailureExplanation := 'An empty collection was not expected'.
-	checkerBuilder
-		checking: [ :asserter | 
-			asserter
-				enforce: [ 1 > 2 ] because: mathFailureExplanation;
-				enforce: [ #() notEmpty ] because: collectionSizeFailureExplanation ].
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+			AssertionChecker check: [ :asserter |
+				asserter
+					enforce: [ 1 > 2 ] because: mathFailureExplanation;
+					enforce: [ #(  ) notEmpty ] because: collectionSizeFailureExplanation
+				]
+			]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
-				assert: exception messageText equals: ('<1s>. <2s>' expandMacrosWith: mathFailureExplanation with: collectionSizeFailureExplanation);
+				assert: exception messageText
+				equals:
+					( '<1s>. <2s>' expandMacrosWith: mathFailureExplanation with: collectionSizeFailureExplanation );
 				assertCollection: exception failures
-					hasSameElements:
-					{mathFailureExplanation.
-					collectionSizeFailureExplanation} ]
+				hasSameElements: { mathFailureExplanation. collectionSizeFailureExplanation }
+			]
 ]
 
 { #category : #tests }
@@ -221,30 +251,33 @@ AssertionCheckerBuilderTest >> testSingleConditionFailure [
 	| explanation |
 
 	explanation := 'An obvious math error'.
-	checkerBuilder checking: [ :asserter | asserter enforce: [ 1 > 2 ] because: explanation ].
 	self
-		should: [ checkerBuilder buildAndCheck ]
+		should: [
+		AssertionChecker check: [ :asserter | asserter enforce: [ 1 > 2 ] because: explanation ] ]
 		raise: AssertionFailed
-		withExceptionDo: [ :exception | 
+		withExceptionDo: [ :exception |
 			self
 				assert: exception messageText equals: explanation;
-				assertCollection: exception failures hasSameElements: {explanation} ]
+				assertCollection: exception failures hasSameElements: { explanation }
+			]
 ]
 
 { #category : #tests }
 AssertionCheckerBuilderTest >> testWithoutChecks [
 
-	self shouldnt: [ checkerBuilder buildAndCheck ] raise: AssertionFailed
+	self shouldnt: [ AssertionChecker check: [ :asserter |  ] ] raise: AssertionFailed
 ]
 
 { #category : #tests }
 AssertionCheckerBuilderTest >> testWithoutFailures [
 
-	checkerBuilder
-		checking: [ :asserter | 
-			asserter
-				enforce: [ true ] because: [ self fail ];
-				enforce: [ 1 positive ] because: [ self fail ] ].
-
-	self shouldnt: [ checkerBuilder buildAndCheck ] raise: AssertionFailed
+	self
+		shouldnt: [
+			AssertionChecker check: [ :asserter |
+				asserter
+					enforce: [ true ] because: [ self fail ];
+					enforce: [ 1 positive ] because: [ self fail ]
+				]
+			]
+		raise: AssertionFailed
 ]

--- a/source/Buoy-Assertions/AssertionChecker.class.st
+++ b/source/Buoy-Assertions/AssertionChecker.class.st
@@ -8,13 +8,30 @@ Class {
 		'asserter',
 		'failurePolicy'
 	],
-	#category : 'Buoy-Assertions'
+	#category : #'Buoy-Assertions'
 }
 
 { #category : #'instance creation' }
 AssertionChecker class >> applying: aFailurePolicy to: anAsserter [
 
 	^ self new initializeApplying: aFailurePolicy to: anAsserter
+]
+
+{ #category : #checking }
+AssertionChecker class >> check: checkingBlock [
+
+	^ self check: checkingBlock configuredBy: [ :checker |  ]
+]
+
+{ #category : #checking }
+AssertionChecker class >> check: checkingBlock configuredBy: configurationBlock [
+
+	| builder |
+
+	builder := AssertionCheckerBuilder new.
+	configurationBlock value: builder.
+	builder checking: checkingBlock.
+	^ builder buildAndCheck
 ]
 
 { #category : #private }


### PR DESCRIPTION
Change direct references to `AssertionCheckerBuilder` and instead use `AssertionChecker`, so it will be the entry point for using the library.

Also fix some spelling errors