### PR TITLE
GS/64 extensions to base clases needed for Zinc

### DIFF
--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0 ]
+        smalltalk: [ Pharo64-11, Pharo64-10, Pharo64-9.0 ]
         load-spec: [ deployment, dependent-sunit-extensions, tests, tools, development ]
     name: ${{ matrix.smalltalk }} + ${{ matrix.load-spec }}
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smalltalk: [ Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
+        smalltalk: [ Pharo64-11, Pharo64-10, Pharo64-9.0 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ adding useful extensions.
 
 [![GitHub release](https://img.shields.io/github/release/ba-st/Buoy.svg)](https://github.com/ba-st/Buoy/releases/latest)
 
-[![Pharo 7.0](https://img.shields.io/badge/Pharo-7.0-informational)](https://pharo.org)
-[![Pharo 8.0](https://img.shields.io/badge/Pharo-8.0-informational)](https://pharo.org)
 [![Pharo 9.0](https://img.shields.io/badge/Pharo-9.0-informational)](https://pharo.org)
 [![Pharo 10](https://img.shields.io/badge/Pharo-10-informational)](https://pharo.org)
 [![Pharo 11](https://img.shields.io/badge/Pharo-11-informational)](https://pharo.org)

--- a/rowan/components/Deployment.ston
+++ b/rowan/components/Deployment.ston
@@ -1,6 +1,7 @@
 RwSimpleProjectLoadComponentV2 {
   #name : 'Deployment',
   #preloadDoitName : 'scripts/defineExceptionAliases',
+  #postloadDoitName : 'scripts/definePostLoadExceptionAliases',
   #projectNames : [ ],
   #componentNames : [ ],
   #packageNames : [

--- a/rowan/components/scripts/defineExceptionAliases.st
+++ b/rowan/components/scripts/defineExceptionAliases.st
@@ -5,6 +5,8 @@ symbolDictionary := Rowan image
 			Rowan image symbolList createDictionaryNamed: 'Buoy' at: 1.
 			Rowan image symbolDictNamed: 'Buoy'
 	].
-symbolDictionary at: #SubscriptOutOfBounds put: OffsetError.
-symbolDictionary at: #NotFound put: LookupError.
+
 symbolDictionary at: #ArithmeticError put: NumericError.
+symbolDictionary at: #KeyNotFound put: LookupError.
+symbolDictionary at: #NotFound put: LookupError.
+symbolDictionary at: #SubscriptOutOfBounds put: OffsetError.

--- a/rowan/components/scripts/defineExceptionAliases.st
+++ b/rowan/components/scripts/defineExceptionAliases.st
@@ -10,3 +10,4 @@ symbolDictionary at: #ArithmeticError put: NumericError.
 symbolDictionary at: #KeyNotFound put: LookupError.
 symbolDictionary at: #NotFound put: LookupError.
 symbolDictionary at: #SubscriptOutOfBounds put: OffsetError.
+symbolDictionary at: #AssertionFailure put: AssertionFailed.

--- a/rowan/components/scripts/defineExceptionAliases.st
+++ b/rowan/components/scripts/defineExceptionAliases.st
@@ -2,7 +2,7 @@
 symbolDictionary := Rowan image 
 	symbolDictNamed: 'Buoy'
 	ifAbsent: [
-			Rowan image symbolList createDictionaryNamed: 'Buoy' at: 1.
+			Rowan image symbolList createDictionaryNamed: 'Buoy' at: Rowan image symbolList size + 1.
 			Rowan image symbolDictNamed: 'Buoy'
 	].
 
@@ -10,4 +10,3 @@ symbolDictionary at: #ArithmeticError put: NumericError.
 symbolDictionary at: #KeyNotFound put: LookupError.
 symbolDictionary at: #NotFound put: LookupError.
 symbolDictionary at: #SubscriptOutOfBounds put: OffsetError.
-symbolDictionary at: #AssertionFailure put: AssertionFailed.

--- a/rowan/components/scripts/definePostLoadExceptionAliases.st
+++ b/rowan/components/scripts/definePostLoadExceptionAliases.st
@@ -1,0 +1,8 @@
+| symbolDictionary |
+symbolDictionary := Rowan image 
+	symbolDictNamed: 'Buoy'
+	ifAbsent: [
+    Error sigan: 'Missing Buoy symbol dictionary'  
+	].
+
+symbolDictionary at: #AssertionFailure put: AssertionFailed.

--- a/rowan/components/scripts/definePostLoadExceptionAliases.st
+++ b/rowan/components/scripts/definePostLoadExceptionAliases.st
@@ -2,7 +2,7 @@
 symbolDictionary := Rowan image 
 	symbolDictNamed: 'Buoy'
 	ifAbsent: [
-    Error sigan: 'Missing Buoy symbol dictionary'  
+    Error signal: 'Missing Buoy symbol dictionary'  
 	].
 
 symbolDictionary at: #AssertionFailure put: AssertionFailed.

--- a/source/Buoy-Collections-Extensions/Collection.extension.st
+++ b/source/Buoy-Collections-Extensions/Collection.extension.st
@@ -7,6 +7,13 @@ Collection >> asOrderedSet [
 ]
 
 { #category : #'*Buoy-Collections-Extensions' }
+Collection >> includesIdenticalTo: anObject [
+
+	self do: [ :each | anObject == each ifTrue: [ ^ true ] ].
+	^ false
+]
+
+{ #category : #'*Buoy-Collections-Extensions' }
 Collection >> maxUsing: aBlock [
 
 	^ self maxUsing: aBlock ifEmpty: [ self errorEmptyCollection ]

--- a/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
@@ -17,8 +17,6 @@ AbstractDictionary class >> newFromPairs: anArray [
 	"Answer an instance of me associating (anArray at: i) to (anArray at: i+1)
 	 for each odd i.  anArray must have an even number of entries."
 
-	"Dictionary newFromPairs: {'Red' . Color red . 'Blue' . Color blue . 'Green' . Color green}."
-
 	| newDictionary |
 	newDictionary := self new: anArray size / 2.
 	1 to: anArray size - 1 by: 2 do: [ :i | newDictionary at: (anArray at: i) put: (anArray at: i + 1) ].

--- a/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
@@ -1,6 +1,20 @@
 Extension { #name : #AbstractDictionary }
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+AbstractDictionary >> at: key ifPresent: aBlock [
+
+	^ self at: key ifPresent: aBlock ifAbsent: [ nil ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+AbstractDictionary >> at: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
+
+	| presentValue |
+	presentValue := self at: key ifAbsent: [ ^ anAbsentBlock value ].
+	^ aPresentBlock cull: presentValue
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 AbstractDictionary >> at: key ifPresent: aBlock ifAbsentPut: anAbsentBlock [
 
 	| presentValue |

--- a/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
@@ -11,3 +11,16 @@ AbstractDictionary >> at: key ifPresent: aBlock ifAbsentPut: anAbsentBlock [
 		                ^ absentValue ].
 	^ aBlock cull: presentValue
 ]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+AbstractDictionary class >> newFromPairs: anArray [
+	"Answer an instance of me associating (anArray at: i) to (anArray at: i+1)
+	 for each odd i.  anArray must have an even number of entries."
+
+	"Dictionary newFromPairs: {'Red' . Color red . 'Blue' . Color blue . 'Green' . Color green}."
+
+	| newDictionary |
+	newDictionary := self new: anArray size / 2.
+	1 to: anArray size - 1 by: 2 do: [ :i | newDictionary at: (anArray at: i) put: (anArray at: i + 1) ].
+	^ newDictionary
+]

--- a/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #AbstractDictionary }
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
-AbstractDictionary >> at: key ifPresent: aBlock [
-
-	^ self at: key ifPresent: aBlock ifAbsent: [ nil ]
-]
-
-{ #category : #'*Buoy-Collections-GS64-Extensions' }
 AbstractDictionary >> at: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
 
 	| presentValue |

--- a/source/Buoy-Collections-GS64-Extensions/Array.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Array.extension.st
@@ -10,6 +10,12 @@ Array >> fillFrom: aCollection with: aBlock [
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+Array >> isArray [
+
+	^ true
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 Array class >> newFrom: aCollection [
 	"Answer an instance of me containing the same elements as aCollection."
 

--- a/source/Buoy-Collections-GS64-Extensions/Character.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Character.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Character }
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+Character class >> value: anInteger [
+
+	^self withValue: anInteger 
+]

--- a/source/Buoy-Collections-GS64-Extensions/CharacterCollection.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/CharacterCollection.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #CharacterCollection }
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection class >> cr [
+
+	^ self with: Character cr
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 CharacterCollection >> expandMacros [
 
 	^ self expandMacrosWithArguments: #(  )
@@ -86,6 +92,12 @@ CharacterCollection >> expandMacrosWithArguments: anArray [
 									(char == $%
 										ifTrue: [ readStream next ]
 										ifFalse: [ char ]) ] ] ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection class >> lf [
+
+	^ self with: Character lf
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }

--- a/source/Buoy-Collections-GS64-Extensions/Collection.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Collection.extension.st
@@ -16,6 +16,16 @@ Collection >> as: aSimilarClass [
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+Collection >> associationsDo: aBlock [
+	"Evaluate aBlock for each of the receiver's elements (key/value
+	associations).  If any non-association is within, the error is not caught now,
+	but later, when a key or value message is sent to it.
+	The point of this method it to do the *right thing* on Dictionaries and related classes."
+
+	self do: aBlock
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 Collection >> collect: aBlock as: aClass [
 	"Evaluate aBlock with each of the receiver's elements as the argument.
 	Collect the resulting values into an instance of aClass. Answer the resulting collection."

--- a/source/Buoy-Collections-GS64-Extensions/Collection.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Collection.extension.st
@@ -26,6 +26,12 @@ Collection >> associationsDo: aBlock [
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+Collection >> capacity [
+
+	^ self size
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 Collection >> collect: aBlock as: aClass [
 	"Evaluate aBlock with each of the receiver's elements as the argument.
 	Collect the resulting values into an instance of aClass. Answer the resulting collection."

--- a/source/Buoy-Collections-GS64-Extensions/Object.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Object.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Object }
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+Object >> isArray [
+
+	^ false
+]

--- a/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
+++ b/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
@@ -137,7 +137,11 @@ OrderedDictionary >> associationAt: aKey ifPresent: aBlock [
 
 { #category : #accessing }
 OrderedDictionary >> associationAt: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
-	^ dictionary associationAt: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock
+
+	^ dictionary
+		  associationAt: key
+		  ifPresent: aPresentBlock
+		  ifAbsent: anAbsentBlock
 ]
 
 { #category : #accessing }
@@ -216,23 +220,26 @@ OrderedDictionary >> at: aKey ifAbsentPut: aBlock [
 
 { #category : #accessing }
 OrderedDictionary >> at: aKey ifPresent: aBlock [
-	^ dictionary at: aKey ifPresent: aBlock
+
+	^ self at: aKey ifPresent: aBlock ifAbsent: [ nil ]
 ]
 
 { #category : #accessing }
 OrderedDictionary >> at: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
+
 	^ dictionary
-		at: aKey
-		ifPresent: aPresentBlock
-		ifAbsent: anAbsentBlock
+		  at: aKey
+		  ifPresent: [ :value | aPresentBlock cull: value ]
+		  ifAbsent: anAbsentBlock
 ]
 
 { #category : #accessing }
 OrderedDictionary >> at: aKey ifPresent: aPresentBlock ifAbsentPut: anAbsentBlock [
-	^ dictionary
-		at: aKey
-		ifPresent: aPresentBlock
-		ifAbsent: [ self at: aKey put: anAbsentBlock value ]
+
+	^ self
+		  at: aKey
+		  ifPresent: aPresentBlock
+		  ifAbsent: [ self at: aKey put: anAbsentBlock value ]
 ]
 
 { #category : #accessing }

--- a/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
+++ b/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
@@ -1,0 +1,611 @@
+"
+I am a collection that act as a Dictionary except that I use key insertion order when enumerating, printing, or returing collections of keys/values/associations, but not when testing for equality (but it does not matters in this case).
+I will assume that you know the Dictionary class in this comment.
+
+I work mainly as a Dictionary except that I also store the keys in an Array that keeps the order of elements. 
+I should be used ONLY if you need to keep the keys ordered. Else you should use a Dictionary that is faster and keep less values into memory. (I duplicate the keys).
+Insertion, update, and inclusion testing have O(1) complexity while removing has O(n) worst-case.
+
+### Public API and Key Messages
+
+- #at: aKey put: aValue / #at: aKey ifAbsentPut: aValue / #at: aKey ifPresent: aBlock ifAbsent: aBlock		allow to add an element.  
+- #at: aKey / #at: aKey ifAbsent: aBlock / #at: aKey ifPresent: aBlock ifAbsent: aBlock 		allow to access my values.
+- #keysDo: aBlock / #valuesDo: aBlock / #associationsDo: 		allow to iterate on me effectively.
+- #keyAtIndex: anIndex / KeyAtIndex: anIndex ifAbsent: aBlock 		allow to acess my keys from an index.
+
+### Examples
+	""For basic examples see Dictionary comment.""
+```	
+	ordDic := (Dictionary with: 1 -> $a with: 2 -> $b) asOrderedDictionary.
+	ordDic.   		""returns:  an OrderedDictionary(1->$a 2->$b)""
+	ordDic keyAtIndex: 2.		""returns:  2""
+```
+	
+### Internal Representation and Key Implementation Points.
+Instance Variables
+-	dictionary:			<Dictionary>		A dictionary where I store my keys and values.
+-	orderedKeys:		<Array>			An ordered collection where I store my keys to maintain the order.
+
+I base my implementation on a Dictionary and when I need to execute an action where the order of the values is important I use the keys in my ordered collection.
+"
+Class {
+	#name : #OrderedDictionary,
+	#superclass : #Collection,
+	#instVars : [
+		'dictionary',
+		'orderedKeys'
+	],
+	#category : #'Buoy-Collections-GS64-Extensions'
+}
+
+{ #category : #'instance creation' }
+OrderedDictionary class >> new [
+	^ self new: 10
+]
+
+{ #category : #'instance creation' }
+OrderedDictionary class >> new: aCapacity [
+	^ self basicNew initialize: aCapacity
+]
+
+{ #category : #'instance creation' }
+OrderedDictionary class >> newFrom: anAssociationCollection [
+	| newDictionary |
+
+	newDictionary := self new: anAssociationCollection size.
+	anAssociationCollection associationsDo: [:each |
+		newDictionary
+			at: each key
+			put: each value].
+	^ newDictionary
+]
+
+{ #category : #'instance creation' }
+OrderedDictionary class >> newFromKeys: keys andValues: values [
+	"Create a dictionary from the keys and values arguments which should have the same length."
+
+	| dict |
+	dict := self new: keys size.
+	keys with: values do: [ :k :v | dict at: k put: v ].
+	^ dict
+]
+
+{ #category : #'instance creation' }
+OrderedDictionary class >> newFromPairs: aSequenceableCollection [
+	| newDictionary |
+
+	newDictionary := self new: (aSequenceableCollection size / 2) floor.
+	1 to: aSequenceableCollection size - 1 by: 2 do: [:i |
+		newDictionary
+			at: (aSequenceableCollection at: i)
+			put: (aSequenceableCollection at: i + 1)].
+	^ newDictionary
+]
+
+{ #category : #comparing }
+OrderedDictionary >> = anObject [
+	self == anObject
+		ifTrue: [^ true].
+
+	(self species == anObject species
+		and: [self size = anObject size])
+		ifFalse: [^ false].
+
+	dictionary associationsDo: [:each |
+		(anObject at: each key ifAbsent: [^ false]) = each value
+			ifFalse: [^ false]].
+	^ true
+]
+
+{ #category : #adding }
+OrderedDictionary >> add: anAssociation [
+	| oldSize |
+
+	oldSize := dictionary size.
+	dictionary add: anAssociation.
+	dictionary size > oldSize
+		ifTrue: [
+			orderedKeys size > oldSize
+				ifFalse: [self growOrderedKeys].
+			orderedKeys at: oldSize + 1 put: anAssociation key].
+	^ anAssociation
+]
+
+{ #category : #adding }
+OrderedDictionary >> addAll: anAssociationCollection [
+	"Since Collection implements #associationsDo:, this method can accept
+	any collection of associations including Arrays and OrderedCollections"
+
+	anAssociationCollection associationsDo: [:each | self add: each].
+	^ anAssociationCollection
+]
+
+{ #category : #accessing }
+OrderedDictionary >> associationAt: aKey [
+	^ dictionary associationAt: aKey
+]
+
+{ #category : #accessing }
+OrderedDictionary >> associationAt: aKey ifAbsent: aBlock [
+	^ dictionary associationAt: aKey ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> associationAt: aKey ifPresent: aBlock [
+	^ dictionary associationAt: aKey ifPresent: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> associationAt: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
+	^ dictionary associationAt: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> associations [
+	| associations i |
+
+	associations := Array new: self size.
+	i := 1.
+	self associationsDo: [:each |
+		associations at: i put: each.
+		i := i + 1].
+	^ associations
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> associationsDo: aBlock [
+	self keysDo: [:each | aBlock value: (self associationAt: each)]
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> associationsSelect: aBlock [
+	^ self species newFrom: (self associations select: aBlock)
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey [
+	^ dictionary at: aKey
+]
+
+{ #category : #'nested dictionaries' }
+OrderedDictionary >> at: firstKey at: secondKey [
+	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey."
+
+	^ self
+		  at: firstKey
+		  at: secondKey
+		  ifAbsent: [ self errorKeyNotFound: secondKey ]
+]
+
+{ #category : #'nested dictionaries' }
+OrderedDictionary >> at: firstKey at: secondKey ifAbsent: aZeroArgBlock [
+		"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. Execute aZeroArgBlock in case one of the key is wrong."
+
+	| subDictionary |
+	subDictionary := self at: firstKey ifAbsent: [ ^ aZeroArgBlock value ].
+	^ subDictionary at: secondKey ifAbsent: aZeroArgBlock
+]
+
+{ #category : #'nested dictionaries' }
+OrderedDictionary >> at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock [
+	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. If firstKey is not defined, set a new dictionary for the second key and set the value of aZeroArgBlock execution. If firstKey is defined and not second key set the value of aZeroArgBlock execution. See NestedDictionaryTest for examples."
+
+	| subDictionary |
+	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	^ subDictionary at: secondKey ifAbsentPut: aZeroArgBlock
+]
+
+{ #category : #'nested dictionaries' }
+OrderedDictionary >> at: firstKey at: secondKey put: aValue [
+	"Set a value at secondKey in the dictionary returned by firstKey."
+
+	| subDictionary |
+	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	^ subDictionary at: secondKey put: aValue
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey ifAbsent: aBlock [
+	^ dictionary at: aKey ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey ifAbsentPut: aBlock [
+	^ self at: aKey ifAbsent: [self at: aKey put: aBlock value]
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey ifPresent: aBlock [
+	^ dictionary at: aKey ifPresent: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
+	^ dictionary
+		at: aKey
+		ifPresent: aPresentBlock
+		ifAbsent: anAbsentBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey ifPresent: aPresentBlock ifAbsentPut: anAbsentBlock [
+	^ dictionary
+		at: aKey
+		ifPresent: aPresentBlock
+		ifAbsent: [ self at: aKey put: anAbsentBlock value ]
+]
+
+{ #category : #accessing }
+OrderedDictionary >> at: aKey put: aValue [
+	| oldSize |
+
+	oldSize := dictionary size.
+	dictionary at: aKey put: aValue.
+	dictionary size > oldSize
+		ifTrue: [
+			orderedKeys size > oldSize
+				ifFalse: [self growOrderedKeys].
+			orderedKeys at: oldSize + 1 put: aKey].
+	^ aValue
+]
+
+{ #category : #accessing }
+OrderedDictionary >> bindingOf: varName [
+	^ self associationAt: varName ifAbsent: [nil]
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> bindingsDo: aBlock [
+	self associationsDo: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> capacity [
+	^ dictionary capacity
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> collect: aBlock [
+	^ self species newFrom:
+		(self associations collect: [:each |
+			each key -> (aBlock value: each value)])
+]
+
+{ #category : #adding }
+OrderedDictionary >> declare: aKey from: aDictionary [
+	(self includesKey: aKey)
+		ifTrue: [^ self].
+
+	(aDictionary includesKey: aKey)
+		ifTrue: [
+			self add: (aDictionary associationAt: aKey).
+			aDictionary removeKey: aKey]
+		ifFalse: [self add: aKey -> nil]
+]
+
+{ #category : #private }
+OrderedDictionary >> dictionary [
+	^ dictionary
+]
+
+{ #category : #accessing }
+OrderedDictionary >> dictionaryClass [
+	^ Dictionary
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> do: aBlock [
+	self valuesDo: aBlock
+]
+
+{ #category : #private }
+OrderedDictionary >> errorInvalidIndex: anIndex [
+
+	^ SubscriptOutOfBounds signal:
+		  ('Subscript (<1p>) out of bounds' expandMacrosWith: anIndex)
+]
+
+{ #category : #private }
+OrderedDictionary >> errorKeyNotFound: aKey [
+
+	^ KeyNotFound signal: ('Key <1p> not found' expandMacrosWith: aKey)
+]
+
+{ #category : #private }
+OrderedDictionary >> growOrderedKeys [
+	orderedKeys :=
+		(Array new: ((orderedKeys size * 1.5) asInteger max: 10))
+			replaceFrom: 1
+			to: orderedKeys size
+			with: orderedKeys
+			startingAt: 1
+]
+
+{ #category : #testing }
+OrderedDictionary >> hasBindingThatBeginsWith: aString [
+	^ dictionary hasBindingThatBeginsWith: aString
+]
+
+{ #category : #comparing }
+OrderedDictionary >> hash [
+	^ dictionary hash
+]
+
+{ #category : #accessing }
+OrderedDictionary >> identityIndexOfKey: aKey [
+	^ self identityIndexOfKey: aKey ifAbsent: [0]
+]
+
+{ #category : #accessing }
+OrderedDictionary >> identityIndexOfKey: aKey ifAbsent: aBlock [
+	1 to: self size do: [:i |
+		(orderedKeys at: i) == aKey
+			ifTrue: [^ i]].
+	^ aBlock value
+]
+
+{ #category : #testing }
+OrderedDictionary >> includes: anObject [
+	^ dictionary includes: anObject
+]
+
+{ #category : #testing }
+OrderedDictionary >> includesAssociation: anAssociation [
+	^ dictionary includesAssociation: anAssociation
+]
+
+{ #category : #testing }
+OrderedDictionary >> includesIdentity: anObject [
+	^ dictionary includesIdentity: anObject
+]
+
+{ #category : #testing }
+OrderedDictionary >> includesKey: aKey [
+	^ dictionary includesKey: aKey
+]
+
+{ #category : #accessing }
+OrderedDictionary >> indexOfKey: aKey [
+	^ self indexOfKey: aKey ifAbsent: [0]
+]
+
+{ #category : #accessing }
+OrderedDictionary >> indexOfKey: aKey ifAbsent: aBlock [
+	1 to: self size do: [:i |
+		(orderedKeys at: i) = aKey
+			ifTrue: [^ i]].
+	^ aBlock value
+]
+
+{ #category : #initialization }
+OrderedDictionary >> initialize: aCapacity [
+	dictionary := self dictionaryClass new: aCapacity.
+	orderedKeys := Array new: aCapacity
+]
+
+{ #category : #testing }
+OrderedDictionary >> isDictionary [
+	^ true
+]
+
+{ #category : #testing }
+OrderedDictionary >> isHealthy [
+	^ dictionary isHealthy
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyAtIdentityValue: aValue [
+	^ dictionary keyAtIdentityValue: aValue
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyAtIdentityValue: aValue ifAbsent: aBlock [
+	^ dictionary keyAtIdentityValue: aValue ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyAtIndex: anIndex [
+	^ self keyAtIndex: anIndex ifAbsent: [self errorInvalidIndex: anIndex]
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyAtIndex: anIndex ifAbsent: aBlock [
+	^ (anIndex > 0 and: [ anIndex <= self size ])
+		ifTrue: [ orderedKeys at: anIndex ]
+		ifFalse: [ aBlock value ]
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyAtValue: aValue [
+	^ dictionary keyAtValue: aValue
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyAtValue: aValue ifAbsent: aBlock [
+	^ dictionary keyAtValue: aValue ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keyForIdentity: anObject [
+	^ dictionary keyForIdentity: anObject
+]
+
+{ #category : #accessing }
+OrderedDictionary >> keys [
+	^ orderedKeys copyFrom: 1 to: self size
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> keysAndValuesDo: aBlock [
+	self keysDo: [:each | aBlock value: each value: (self at: each)]
+]
+
+{ #category : #removing }
+OrderedDictionary >> keysAndValuesRemove: aTwoArgumentBlock [
+	| removedAssociations |
+
+	removedAssociations := OrderedCollection new.
+	self associationsDo: [:each |
+		(aTwoArgumentBlock value: each key value: each value)
+			ifTrue: [removedAssociations add: each]].
+	removedAssociations do: [:each | self removeKey: each key]
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> keysDo: aBlock [
+	1 to: self size do: [:i | aBlock value: (orderedKeys at: i)]
+]
+
+{ #category : #private }
+OrderedDictionary >> orderedKeys [
+	^ orderedKeys
+]
+
+{ #category : #private }
+OrderedDictionary >> orderedKeysIndexOf: aKey [
+	^ orderedKeys indexOf: aKey
+]
+
+{ #category : #private }
+OrderedDictionary >> orderedKeysRemove: aRemovedKey [
+	| index |
+
+	index := self orderedKeysIndexOf: aRemovedKey.
+
+	"shift every remaining key after to the left by one"
+	orderedKeys
+		replaceFrom: index
+		to: self size
+		with: orderedKeys
+		startingAt: index + 1.
+
+	"one key was removed and the rest shifted, so nil what was the last
+	key slot before removing and shifting"
+	orderedKeys
+		at: self size + 1
+		put: nil
+]
+
+{ #category : #copying }
+OrderedDictionary >> postCopy [
+	orderedKeys := orderedKeys copy.
+	dictionary := dictionary copy
+]
+
+{ #category : #printing }
+OrderedDictionary >> printElementsOn: aStream [
+	aStream nextPut: $(.
+	self size > 100
+		ifTrue: [
+			aStream nextPutAll: 'size '.
+			self size printOn: aStream]
+		ifFalse: [
+			self associations withIndexDo: [:each :i |
+				aStream
+					print: each key;
+					nextPutAll: '->';
+					print: each value.
+				(i < self size)
+					ifTrue: [aStream space]]].
+	aStream nextPut: $)
+]
+
+{ #category : #removing }
+OrderedDictionary >> remove: anObject ifAbsent: aBlock [
+	self shouldNotImplement
+]
+
+{ #category : #removing }
+OrderedDictionary >> removeAll [
+	1 to: self size do: [:i | orderedKeys at: i put: nil].
+	dictionary removeAll
+]
+
+{ #category : #removing }
+OrderedDictionary >> removeKey: aKey [
+	| value |
+
+	value := dictionary removeKey: aKey.
+	self orderedKeysRemove: aKey.
+	^ value
+]
+
+{ #category : #removing }
+OrderedDictionary >> removeKey: aKey ifAbsent: aBlock [
+	| oldSize value |
+
+	oldSize := dictionary size.
+	value := dictionary removeKey: aKey ifAbsent: aBlock.
+	dictionary size < oldSize
+		ifTrue: [self orderedKeysRemove: aKey].
+	^ value
+]
+
+{ #category : #removing }
+OrderedDictionary >> removeKeys: aKeyCollection [
+	"Fast removal of multiple keys; returns self to avoid
+	having to create a removed value collection and does not
+	raise errors."
+
+	aKeyCollection	size > 1
+		ifTrue: [| oldSize newOrderedKeys newOrderedKeysIndex |
+			oldSize := self size.
+			aKeyCollection do: [:each |
+				dictionary
+					removeKey: each
+					ifAbsent: [nil]].
+
+			newOrderedKeys := Array new: oldSize.
+			newOrderedKeysIndex := 0.
+			1 to: oldSize do: [:i | | key |
+				(dictionary includesKey: (key := orderedKeys at: i))
+					ifTrue: [
+						newOrderedKeys
+							at: (newOrderedKeysIndex := newOrderedKeysIndex + 1)
+							put: key]].
+
+			orderedKeys := newOrderedKeys]
+		ifFalse: [
+			aKeyCollection size = 1
+				ifTrue: [
+					"use #anyOne, because it can be a Set"
+					self
+						removeKey: aKeyCollection anyOne
+						ifAbsent: [nil]]]
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> select: aBlock [
+	^ self species newFrom:
+		(self associations select: [:each | aBlock value: each value])
+]
+
+{ #category : #accessing }
+OrderedDictionary >> size [
+	^ dictionary size
+]
+
+{ #category : #printing }
+OrderedDictionary >> storeOn: aStream [
+	aStream << '((' << self class name << ' new)'.
+	self associations
+		ifNotEmpty: [ :assos |
+			assos
+				do: [ :each |
+					aStream
+						<< ' add: ';
+						store: each ]
+				separatedBy: [ aStream << ';' ].
+			aStream << '; yourself' ].
+	aStream << ')'
+]
+
+{ #category : #accessing }
+OrderedDictionary >> values [
+	^ self associations collect: [:each | each value]
+]
+
+{ #category : #enumerating }
+OrderedDictionary >> valuesDo: aBlock [
+	self keysDo: [:each | aBlock value: (self at: each)]
+]

--- a/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
+++ b/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
@@ -401,43 +401,6 @@ OrderedDictionary >> isHealthy [
 ]
 
 { #category : #accessing }
-OrderedDictionary >> keyAtIdentityValue: aValue [
-	^ dictionary keyAtIdentityValue: aValue
-]
-
-{ #category : #accessing }
-OrderedDictionary >> keyAtIdentityValue: aValue ifAbsent: aBlock [
-	^ dictionary keyAtIdentityValue: aValue ifAbsent: aBlock
-]
-
-{ #category : #accessing }
-OrderedDictionary >> keyAtIndex: anIndex [
-	^ self keyAtIndex: anIndex ifAbsent: [self errorInvalidIndex: anIndex]
-]
-
-{ #category : #accessing }
-OrderedDictionary >> keyAtIndex: anIndex ifAbsent: aBlock [
-	^ (anIndex > 0 and: [ anIndex <= self size ])
-		ifTrue: [ orderedKeys at: anIndex ]
-		ifFalse: [ aBlock value ]
-]
-
-{ #category : #accessing }
-OrderedDictionary >> keyAtValue: aValue [
-	^ dictionary keyAtValue: aValue
-]
-
-{ #category : #accessing }
-OrderedDictionary >> keyAtValue: aValue ifAbsent: aBlock [
-	^ dictionary keyAtValue: aValue ifAbsent: aBlock
-]
-
-{ #category : #accessing }
-OrderedDictionary >> keyForIdentity: anObject [
-	^ dictionary keyForIdentity: anObject
-]
-
-{ #category : #accessing }
 OrderedDictionary >> keys [
 	^ orderedKeys copyFrom: 1 to: self size
 ]

--- a/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
+++ b/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
@@ -278,6 +278,12 @@ OrderedDictionary >> collect: aBlock [
 			each key -> (aBlock value: each value)])
 ]
 
+{ #category : #copying }
+OrderedDictionary >> copyEmpty [
+
+	^ self species new
+]
+
 { #category : #adding }
 OrderedDictionary >> declare: aKey from: aDictionary [
 	(self includesKey: aKey)

--- a/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
+++ b/source/Buoy-Collections-GS64-Extensions/OrderedDictionary.class.st
@@ -131,11 +131,6 @@ OrderedDictionary >> associationAt: aKey ifAbsent: aBlock [
 ]
 
 { #category : #accessing }
-OrderedDictionary >> associationAt: aKey ifPresent: aBlock [
-	^ dictionary associationAt: aKey ifPresent: aBlock
-]
-
-{ #category : #accessing }
 OrderedDictionary >> associationAt: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
 
 	^ dictionary
@@ -493,8 +488,9 @@ OrderedDictionary >> remove: anObject ifAbsent: aBlock [
 
 { #category : #removing }
 OrderedDictionary >> removeAll [
-	1 to: self size do: [:i | orderedKeys at: i put: nil].
-	dictionary removeAll
+
+	1 to: self size do: [ :i | orderedKeys at: i put: nil ].
+	dictionary keys copy do: [ :key | dictionary removeKey: key ]
 ]
 
 { #category : #removing }

--- a/source/Buoy-Collections-GS64-Extensions/PositionableStream.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/PositionableStream.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #PositionableStream }
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+PositionableStream >> isBinary [
+	"Return true if the receiver is a binary byte stream"
+	^collection class == ByteArray
+]

--- a/source/Buoy-Collections-Tests/DictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/DictionaryExtensionsTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : #DictionaryExtensionsTest,
+	#superclass : #TestCase,
+	#category : #'Buoy-Collections-Tests'
+}
+
+{ #category : #tests }
+DictionaryExtensionsTest >> testAtIfPresentIfAbsentPut [
+
+	| dictionary wasPresent |
+	dictionary := Dictionary new.
+	dictionary at: #one ifPresent: [ self fail ] ifAbsentPut: [ 1 ].
+	self assert: (dictionary at: #one) equals: 1.
+	wasPresent := false.
+	dictionary
+		at: #one
+		ifPresent: [ :one |
+			wasPresent := true.
+			self assert: one equals: 1 ]
+		ifAbsentPut: [ self fail ].
+	self assert: wasPresent
+]
+
+{ #category : #tests }
+DictionaryExtensionsTest >> testNewFromPairs [
+
+	| dictionary |
+	dictionary := Dictionary newFromPairs: #( one 1 two 2 ).
+
+	self
+		assert: dictionary size equals: 2;
+		assert: (dictionary at: #one) equals: 1;
+		assert: (dictionary at: #two) equals: 2
+]

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -393,29 +393,6 @@ OrderedDictionaryExtensionsTest >> testAssociationAtIfAbsent [
 ]
 
 { #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testAssociationAtIfPresent [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self assert:
-			(dictionary
-				associationAt: each key
-				ifPresent: [self fail]) isNil.
-
-		dictionary add: each.
-		self assert:
-			(dictionary
-				associationAt: each key
-				ifPresent: [:assoc | self newValue -> assoc]) equals: (self newValue -> each).
-		"ensure cull: is used"
-		self assert:
-			(dictionary
-				associationAt: each key
-				ifPresent: [self newValue]) equals: self newValue]
-]
-
-{ #category : #'tests - accessing' }
 OrderedDictionaryExtensionsTest >> testAssociations [
 	| dictionary |
 

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -54,15 +54,22 @@ OrderedDictionaryExtensionsTest >> assertIsArray: anArray withElements: aCollect
 
 { #category : #assertions }
 OrderedDictionaryExtensionsTest >> assertIsDictionary: aFirstDictionary copiedFrom: aSecondDictionary withOrderedAssociations: anAssociationCollection [
+
 	self
 		deny: aFirstDictionary identicalTo: aSecondDictionary;
-		deny: aFirstDictionary dictionary identicalTo: aSecondDictionary dictionary;
-		deny: aFirstDictionary orderedKeys identicalTo: aSecondDictionary orderedKeys.
+		deny: aFirstDictionary dictionary
+		identicalTo: aSecondDictionary dictionary;
+		deny: aFirstDictionary orderedKeys
+		identicalTo: aSecondDictionary orderedKeys.
 
 	"esnure the associations were copied (the keys and values can be shared)"
-	aFirstDictionary associations do: [ :each | self deny: (aSecondDictionary associations identityIncludes: each) ].
+	aFirstDictionary associations do: [ :each |
+		self deny:
+			(aSecondDictionary associations includesIdenticalTo: each) ].
 
-	self assertIsDictionary: aFirstDictionary withOrderedAssociations: anAssociationCollection
+	self
+		assertIsDictionary: aFirstDictionary
+		withOrderedAssociations: anAssociationCollection
 ]
 
 { #category : #assertions }

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -911,45 +911,6 @@ OrderedDictionaryExtensionsTest >> testIsDictionary [
 ]
 
 { #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyAtIdentityValue [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self
-			should: [dictionary keyAtIdentityValue: each value]
-			raise: Error.
-
-		dictionary add: each.
-		self assert: (dictionary keyAtIdentityValue: each value) equals: each key.
-		self
-			should: [dictionary keyAtIdentityValue: each value copy]
-			raise: Error]
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyAtIdentityValueIfAbsent [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self assert:
-			(dictionary
-				keyAtIdentityValue: each value
-				ifAbsent: [self absentKey]) equals: self absentKey.
-
-		dictionary add: each.
-		self assert:
-			(dictionary
-				keyAtIdentityValue: each value
-				ifAbsent: [self fail]) equals: each key.
-		self assert:
-			(dictionary
-				keyAtIdentityValue: each value copy
-				ifAbsent: [self absentKey]) equals: self absentKey]
-]
-
-{ #category : #'tests - accessing' }
 OrderedDictionaryExtensionsTest >> testKeyAtIndex [
 	| dictionary |
 
@@ -964,74 +925,6 @@ OrderedDictionaryExtensionsTest >> testKeyAtIndex [
 
 		dictionary add: each.
 		self assert: (dictionary keyAtIndex: i) equals: each key]
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyAtIndexIfAbsent [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self assert:
-		(dictionary
-			keyAtIndex: 0
-			ifAbsent: [self absentKey]) equals: self absentKey.
-	self orderedAssociations withIndexDo: [:each :i |
-		self assert:
-			(dictionary
-				keyAtIndex: i
-				ifAbsent: [self absentKey]) equals: self absentKey.
-
-		dictionary add: each.
-		self assert:
-			(dictionary
-				keyAtIndex: i
-				ifAbsent: [self fail]) equals: each key]
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyAtValue [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self
-			should: [dictionary keyAtValue: each value]
-			raise: Error.
-
-		dictionary add: each.
-		self assert: (dictionary keyAtValue: each value) equals: each key]
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyAtValueIfAbsent [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self assert:
-			(dictionary
-				keyAtValue: each value
-				ifAbsent: [self absentKey]) equals: self absentKey.
-
-		dictionary add: each.
-		self assert:
-			(dictionary
-				keyAtValue: each value
-				ifAbsent: [self fail]) equals: each key]
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyForIdentity [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self assert: (dictionary keyForIdentity: each value) isNil.
-
-		dictionary add: each.
-		self
-			assert: (dictionary keyForIdentity: each value) equals: each key;
-			assert: (dictionary keyForIdentity: each value copy) isNil]
 ]
 
 { #category : #'tests - accessing' }

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -1,0 +1,1292 @@
+"
+This class tests the OrderedDictionary class. It is separate from DictionaryTest to test that accessing, enumerating, and printing methods preserve the order that keys were inserted in.
+"
+Class {
+	#name : #OrderedDictionaryExtensionsTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'nonIdentityOrderedAssociations',
+		'identityOrderedAssociations'
+	],
+	#category : #'Buoy-Collections-Tests'
+}
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> absentKey [
+
+	^self isTestingIdentityDictionary
+		ifTrue: [ self identityAbsentKey ]
+		ifFalse: [ self nonIdentityAbsentKey ]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> absentValue [
+	^ 'absentValue'
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertDictionary: aFirstDictionary doesNotEqual: aSecondDictionary [
+	"Test symmetric inequality"
+
+	self
+		deny: aFirstDictionary equals: aSecondDictionary;
+		deny: aSecondDictionary equals: aFirstDictionary
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertDictionary: aFirstDictionary equals: aSecondDictionary [
+	"Test reflixive and symmetric equality."
+
+	self
+		assert: aFirstDictionary equals: aFirstDictionary;
+		assert: aFirstDictionary equals: aSecondDictionary;
+		assert: aSecondDictionary equals: aSecondDictionary;
+		assert: aSecondDictionary equals: aFirstDictionary
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertIsArray: anArray withElements: aCollection [
+
+	self
+		assert: anArray isArray;
+		assert: anArray equals: aCollection asArray
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertIsDictionary: aFirstDictionary copiedFrom: aSecondDictionary withOrderedAssociations: anAssociationCollection [
+	self
+		deny: aFirstDictionary identicalTo: aSecondDictionary;
+		deny: aFirstDictionary dictionary identicalTo: aSecondDictionary dictionary;
+		deny: aFirstDictionary orderedKeys identicalTo: aSecondDictionary orderedKeys.
+
+	"esnure the associations were copied (the keys and values can be shared)"
+	aFirstDictionary associations do: [ :each | self deny: (aSecondDictionary associations identityIncludes: each) ].
+
+	self assertIsDictionary: aFirstDictionary withOrderedAssociations: anAssociationCollection
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertIsDictionary: anObject withOrderedAssociations: anAssociationCollection [
+	"Tests that anObject is an instance of the correct dictionary class
+	with the specified ordered associations"
+
+	self
+		assert: anObject class identicalTo: self dictionaryClass;
+		assert: anObject orderedKeys size >= anAssociationCollection size;
+		assert: anObject associations size equals: anAssociationCollection size.
+
+	anAssociationCollection
+		withIndexDo: [ :each :i |
+			self isTestingIdentityDictionary
+				ifTrue: [ self
+						assert: (anObject orderedKeys at: i) identicalTo: each key;
+						assert: (anObject associations at: i) key identicalTo: each key ]
+				ifFalse: [ self
+						assert: (anObject orderedKeys at: i) equals: each key;
+						assert: (anObject associations at: i) key equals: each key ].
+			self assert: (anObject associations at: i) value equals: each value ]
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertIsDictionary: anObject withUnorderedAssociations: anAssociationCollection [
+	"Tests that anObject is an instance of the correct dictionary class
+	with the specified associations, but ignoring the order"
+
+	self
+		assert: anObject class identicalTo: self dictionaryClass;
+		assert: anObject size equals: anAssociationCollection size.
+	anAssociationCollection do: [ :each | self assert: (anObject includesAssociation: each) ]
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> assertKey: aKey wasRemovedfrom: aDictionary [
+
+	self deny: (aDictionary includesKey: aKey).
+	aDictionary keys asArray, aDictionary orderedKeys asArray do: [:each |
+		self deny:
+			(self isTestingIdentityDictionary
+				ifTrue: [each == aKey]
+				ifFalse: [each = aKey])]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> changedOrderedAssociations [
+
+	^ self orderedAssociations collect: [:each | each key -> self newValue]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> changedOrderedAssociationsFirst: anInteger [
+
+	^ self changedOrderedAssociations first: anInteger
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> collectClass [
+
+	^ Array
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> defaultCapacity [
+
+	^ self emptyInternalDictionary capacity
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> dictionaryClass [
+
+	^ OrderedDictionary
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> dictionaryWithOrderedAssociations [
+
+	^ self dictionaryClass newFrom: self orderedAssociations
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> emptyDictionary [
+
+	^ self dictionaryClass new
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> emptyInternalDictionary [
+
+	^ self internalDictionaryClass new
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> identityAbsentKey [
+
+	^ self orderedKeys first copy
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> identityOrderedAssociations [
+	"Returns ordered associations to use for identity dictionaries.
+	The keys are all #= equal but #== different, so only an
+	identity dictionary will be able to distinguish them."
+	identityOrderedAssociations
+		ifNil: [| key |
+			key := 'testKey'.
+			identityOrderedAssociations :=
+				Array
+					with: (key := key copy) -> 'testValue'
+					with: (key := key copy) -> 'testValue3'
+					with: (key := key copy) -> 'testValue2'
+					with: (key := key copy) -> 'testValue4'].
+	"Return copies of the associations so they can be safely modified
+	in one test without affecting another, but do not copy the keys
+	and values"
+	^ identityOrderedAssociations collect: [:each | each copy]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> internalDictionaryClass [
+
+	^self isTestingIdentityDictionary
+		ifTrue: [ IdentityDictionary]
+		ifFalse: [ Dictionary]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> internalDictionaryWithAssociations [
+
+	^ self internalDictionaryClass newFrom: self orderedAssociations
+]
+
+{ #category : #testing }
+OrderedDictionaryExtensionsTest >> isTestingIdentityDictionary [
+
+	^ false
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> newValue [
+
+	^ 'newValue'
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> nonIdentityAbsentKey [
+
+	^ 'absentKey'
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> nonIdentityOrderedAssociations [
+	"Returns ordered associations to use for non-identity dictionaries.
+	The keys are all #= and #== different and are returned out of their
+	natural sort order."
+	nonIdentityOrderedAssociations
+		ifNil: [
+			nonIdentityOrderedAssociations :=
+				Array
+					with: 'testKey' -> 'testValue'
+					with: 'testKey3' -> 'testValue3'
+					with: 'testKey2' -> 'testValue2'
+					with: 'testKey4' -> 'testValue4'].
+	"return copies of the associations so they can be safely modified
+	in one test without affecting another, but do not copy the keys
+	and values"
+	^ nonIdentityOrderedAssociations collect: [:each | each copy]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedAssociations [
+	^self isTestingIdentityDictionary
+		ifTrue: [ self identityOrderedAssociations ]
+		ifFalse: [ self nonIdentityOrderedAssociations ]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedAssociationsAllButFirst: anInteger [
+
+	^ self orderedAssociations allButFirst: anInteger
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedAssociationsFirst: anInteger [
+
+	^ self orderedAssociations first: anInteger
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedKeys [
+
+	^ self orderedAssociations collect: [:each | each key]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedKeysFirst: anInteger [
+
+	^ self orderedKeys first: anInteger
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedValues [
+
+	^ self orderedAssociations collect: [:each | each value]
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> orderedValuesFirst: anInteger [
+
+	^ self orderedValues first: anInteger
+]
+
+{ #category : #accessing }
+OrderedDictionaryExtensionsTest >> otherOrderedDictionaryClasses [
+
+	^ OrderedDictionary withAllSubclasses copyWithout: self dictionaryClass
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> should: aBlock enumerate: aCollection [
+	| enumerated |
+
+	enumerated := OrderedCollection new.
+	aBlock value: [:each | enumerated add: each].
+	self assert: enumerated equals: aCollection asOrderedCollection
+]
+
+{ #category : #assertions }
+OrderedDictionaryExtensionsTest >> should: aBlock enumerate: aFirstCollection and: aSecondCollection [
+	| firstEnumerated secondEnumerated |
+
+	firstEnumerated := OrderedCollection new.
+	secondEnumerated := OrderedCollection new.
+	aBlock value: [:first :second |
+		firstEnumerated addLast: first.
+		secondEnumerated addLast: second].
+	self
+		assert: firstEnumerated equals: aFirstCollection asOrderedCollection;
+		assert: secondEnumerated equals: aSecondCollection asOrderedCollection
+]
+
+{ #category : #'tests - adding' }
+OrderedDictionaryExtensionsTest >> testAdd [
+	| dictionary |
+	dictionary := self emptyDictionary.
+	self orderedAssociations
+		withIndexDo: [ :each :i |
+			self
+				deny: (dictionary includesAssociation: each);
+				assert: (dictionary add: each) identicalTo: each;
+				assert: (dictionary includesAssociation: each).
+			self assertIsDictionary: dictionary withOrderedAssociations: (self orderedAssociationsFirst: i) ].
+
+	"ensure adding the same associations doesn't change the order"
+	self orderedAssociations
+		reverseDo: [ :each |
+			self assert: (dictionary add: each) identicalTo: each.
+			self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations ].
+
+	self changedOrderedAssociations
+		withIndexDo: [ :each :i |
+			| old |
+			old := self orderedAssociations at: i.
+			self
+				assert: (dictionary add: each) identicalTo: each;
+				assert: (dictionary includesAssociation: each);
+				deny: (dictionary includesAssociation: old).
+			self assertIsDictionary: dictionary withOrderedAssociations: (self changedOrderedAssociationsFirst: i) , (self orderedAssociationsAllButFirst: i) ]
+]
+
+{ #category : #'tests - adding' }
+OrderedDictionaryExtensionsTest >> testAddAll [
+	| dictionary addedAssociations |
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [ :each | self deny: (dictionary includesAssociation: each) ].
+
+	addedAssociations := self orderedAssociations.
+	self assert: (dictionary addAll: addedAssociations) identicalTo: addedAssociations.
+	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations.
+
+	"ensure adding the same associations doesn't change the order"
+	addedAssociations := self orderedAssociations reversed.
+	self assert: (dictionary addAll: addedAssociations) identicalTo: addedAssociations.
+	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations.
+
+	addedAssociations := self changedOrderedAssociations.
+	self assert: (dictionary addAll: addedAssociations) identicalTo: addedAssociations.
+	self assertIsDictionary: dictionary withOrderedAssociations: self changedOrderedAssociations
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAssociationAt [
+	| dictionary |
+	dictionary := self emptyDictionary.
+	self orderedAssociations
+		do: [ :each |
+			self should: [ dictionary associationAt: each key ] raise: Error.
+
+			dictionary add: each.
+			self assert: (dictionary associationAt: each key) equals: each ]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAssociationAtIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert:
+			(dictionary
+				associationAt: each key
+				ifAbsent: [self absentValue]) equals: self absentValue.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				associationAt: each key
+				ifAbsent: [self fail]) equals: each]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAssociationAtIfPresent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert:
+			(dictionary
+				associationAt: each key
+				ifPresent: [self fail]) isNil.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				associationAt: each key
+				ifPresent: [:assoc | self newValue -> assoc]) equals: (self newValue -> each).
+		"ensure cull: is used"
+		self assert:
+			(dictionary
+				associationAt: each key
+				ifPresent: [self newValue]) equals: self newValue]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAssociations [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		assertIsArray: dictionary associations
+		withElements: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			assertIsArray: dictionary associations
+			withElements: (self orderedAssociationsFirst: i)]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testAssociationsDo [
+
+	| dictionary |
+	dictionary := self emptyDictionary.
+	self
+		should: [:block | dictionary associationsDo: block]
+		enumerate: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			should: [:block | dictionary associationsDo: block]
+			enumerate: (self orderedAssociationsFirst: i)]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testAssociationsSelect [
+	| dictionary |
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	self orderedAssociations do: [:assoc | | selectedAssociations |
+		selectedAssociations := self orderedAssociations copyWithout: assoc.
+		self
+			assertIsDictionary:
+				(dictionary associationsSelect: [:each |
+					selectedAssociations includes: each])
+			copiedFrom: dictionary
+			withOrderedAssociations:
+				(self orderedAssociations select: [:each |
+					selectedAssociations includes: each])]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAt [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self
+			should: [dictionary at: each key]
+			raise: Error.
+
+		dictionary add: each.
+		self assert: (dictionary at: each key) equals: each value]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAtIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert:
+			(dictionary
+				at: each key
+				ifAbsent: [self absentValue]) equals: self absentValue.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				at: each key
+				ifAbsent: [self fail]) equals: each value]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAtIfAbsentPut [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				at: each key
+				ifAbsentPut: [each value]) equals: each value.
+		self assert:
+			(dictionary
+				at: each key
+				ifAbsentPut: [self fail]) equals: each value.
+		self
+			assertIsArray: dictionary keys
+			withElements: (self orderedKeysFirst: i) ]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAtIfPresent [
+	| dictionary |
+	dictionary := self emptyDictionary.
+	self orderedAssociations
+		do: [ :each |
+			self assert: (dictionary at: each key ifPresent: [ self fail ]) isNil.
+
+			dictionary add: each.
+			self assert: (dictionary at: each key ifPresent: [ :value | self newValue -> value ]) equals: self newValue -> each value.
+			"ensure cull: is used"
+			self assert: (dictionary at: each key ifPresent: [ self newValue ]) equals: self newValue ]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAtIfPresentIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [self fail]
+				ifAbsent: [self absentValue]) equals: self absentValue.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [:value | self newValue -> value]
+				ifAbsent: [self fail]) equals: (self newValue -> each value).
+		"ensure cull: is used"
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [self newValue]
+				ifAbsent: [self fail]) equals: self newValue]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAtIfPresentIfAbsentPut [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [ self fail ]
+				ifAbsentPut: [ each value ]) equals: each value.
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [ :it | self newValue -> it ]
+				ifAbsentPut: [self fail]) equals: (self newValue -> each value).
+		self
+			assertIsArray: dictionary keys
+			withElements: (self orderedKeysFirst: i) ]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testAtPut [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				at: each key
+				put: each value) equals: each value.
+		self
+			assertIsDictionary: dictionary
+			withOrderedAssociations: (self orderedAssociationsFirst: i)].
+
+	self changedOrderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				at: each key
+				put: each value) equals: each value.
+		self
+			assertIsDictionary: dictionary
+			withOrderedAssociations:
+				(self changedOrderedAssociationsFirst: i),
+				(self orderedAssociationsAllButFirst: i)]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testBindingsDo [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		should: [:block | dictionary bindingsDo: block]
+		enumerate: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			should: [:block | dictionary bindingsDo: block]
+			enumerate: (self orderedAssociationsFirst: i)]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testCapacity [
+	"The current Dictionary implementation allocates more than specified.
+	The amount allocated may change in the future but it likely won't ever
+	be less than specified, so a >= test is used throughout."
+
+	| defaultCapacity dictionary |
+
+	defaultCapacity := self defaultCapacity.
+	dictionary := self dictionaryClass new.
+	self assert: dictionary capacity >= defaultCapacity.
+
+	dictionary := self dictionaryClass new: (defaultCapacity / 2) asInteger.
+	self assert: dictionary capacity >= (defaultCapacity / 2) asInteger.
+
+	dictionary := self dictionaryClass newFrom: self orderedAssociations.
+	self assert: dictionary capacity >= self orderedAssociations size.
+
+	self orderedAssociations size to: 0 by: -1 do: [:i |
+		self
+			shouldnt: [
+				dictionary := self dictionaryClass new: i.
+				dictionary addAll: self orderedAssociations]
+			raise: Error]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testCollect [
+	| dictionary |
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	self
+		assertIsDictionary:
+			(dictionary collect: [:each | each hash])
+		copiedFrom: dictionary
+		withOrderedAssociations:
+			(self orderedAssociations collect: [:each | each key -> each value hash])
+]
+
+{ #category : #'tests - copying' }
+OrderedDictionaryExtensionsTest >> testCopy [
+	| dictionary copy |
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	copy := dictionary copy.
+	self
+		assertIsDictionary: dictionary
+		withOrderedAssociations: self orderedAssociations.
+	self
+		assertIsDictionary: copy
+		copiedFrom: dictionary
+		withOrderedAssociations: self orderedAssociations
+]
+
+{ #category : #'tests - copying' }
+OrderedDictionaryExtensionsTest >> testCopyEmpty [
+	| dictionary copy |
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	copy := dictionary copyEmpty.
+	self
+		assertIsDictionary: dictionary
+		withOrderedAssociations: self orderedAssociations.
+	self
+		assertIsDictionary: copy
+		copiedFrom: dictionary
+		withOrderedAssociations: #()
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testDeclareFrom [
+	| dictionary otherDictionary |
+	dictionary := self emptyDictionary.
+	otherDictionary := self dictionaryWithOrderedAssociations.
+	self orderedKeys do: [ :each | self assert: (dictionary declare: each from: otherDictionary) identicalTo: dictionary ].
+	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations.
+	self assertEmpty: otherDictionary.
+
+	self orderedKeys
+		do: [ :each |
+			otherDictionary add: each -> self newValue.
+			self assert: (dictionary declare: each from: otherDictionary) identicalTo: dictionary ].
+	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testDictionary [
+	| dictionary |
+	dictionary := self emptyDictionary.
+	self
+		assert: dictionary dictionary class identicalTo: self internalDictionaryClass;
+		assert: dictionary dictionary equals: self emptyInternalDictionary.
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	self
+		assert: dictionary dictionary class identicalTo: self internalDictionaryClass;
+		assert: dictionary dictionary equals: self internalDictionaryWithAssociations
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testDo [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		should: [:block | dictionary do: block]
+		enumerate: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			should: [:block | dictionary do: block]
+			enumerate: (self orderedValuesFirst: i)]
+]
+
+{ #category : #'tests - comparing' }
+OrderedDictionaryExtensionsTest >> testEquals [
+	| dictionaryOne dictionaryTwo |
+
+	dictionaryOne := self emptyDictionary.
+	dictionaryTwo := self emptyDictionary.
+	self
+		assertDictionary: dictionaryOne
+		equals: dictionaryTwo.
+
+	"For equality, order will not matter"
+	self orderedAssociations
+		with: self orderedAssociations reversed
+		do: [:firstAssociation :secondAssociation |
+			dictionaryOne add: firstAssociation.
+			dictionaryTwo add: secondAssociation.
+			self
+				assertDictionary: dictionaryOne
+				doesNotEqual: self emptyDictionary.
+			self
+				assertDictionary: dictionaryTwo
+				doesNotEqual: self emptyDictionary.
+			dictionaryOne size < self orderedAssociations size
+				ifTrue: [
+					self
+						assertDictionary: dictionaryOne
+						doesNotEqual: dictionaryTwo]].
+
+	self
+		assertDictionary: dictionaryOne
+		equals: dictionaryTwo
+]
+
+{ #category : #'tests - comparing' }
+OrderedDictionaryExtensionsTest >> testEqualsDictionary [
+	self
+		assertDictionary: self emptyDictionary
+		doesNotEqual: self emptyInternalDictionary.
+
+	self
+		assertDictionary: self dictionaryWithOrderedAssociations
+		doesNotEqual: self internalDictionaryWithAssociations
+]
+
+{ #category : #'tests - comparing' }
+OrderedDictionaryExtensionsTest >> testHash [
+	| dictionary otherDictionary internalDictionary otherInternalDictionary |
+	dictionary := self emptyDictionary.
+	otherDictionary := self emptyDictionary.
+	internalDictionary := self emptyInternalDictionary.
+	otherInternalDictionary := self emptyInternalDictionary.
+	self assert: dictionary hash equals: otherDictionary hash.
+	self orderedAssociations
+		do: [ :each |
+			dictionary add: each.
+			internalDictionary add: each copy.
+			"if the internal hashes differ after adding to one, the external should too"
+			internalDictionary hash = otherInternalDictionary hash ifFalse: [ self deny: dictionary hash equals: otherDictionary hash ].
+
+			otherDictionary add: each copy.
+			otherInternalDictionary add: each copy.
+			"should be equal regardless now"
+			self assert: dictionary hash equals: otherDictionary hash ]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testIdentityIndexOfKey [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert: (dictionary identityIndexOfKey: each key) equals: 0.
+
+		dictionary add: each.
+		self
+			assert: (dictionary identityIndexOfKey: each key) equals: i;
+			assert: (dictionary identityIndexOfKey: each key copy) equals: 0]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testIdentityIndexOfKeyIfAbsent [
+	| dictionary |
+	dictionary := self emptyDictionary.
+	self orderedAssociations
+		withIndexDo: [ :each :i |
+			self assert: (dictionary identityIndexOfKey: each key ifAbsent: [ self absentValue ]) equals: self absentValue.
+
+			dictionary add: each.
+			self assert: (dictionary identityIndexOfKey: each key ifAbsent: [ self fail ]) equals: i.
+			self assert: (dictionary identityIndexOfKey: each key copy ifAbsent: [ self absentValue ]) equals: self absentValue ]
+]
+
+{ #category : #'tests - testing' }
+OrderedDictionaryExtensionsTest >> testIncludes [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self deny: (dictionary includes: each value).
+
+		dictionary add: each.
+		self assert: (dictionary includes: each value)]
+]
+
+{ #category : #'tests - testing' }
+OrderedDictionaryExtensionsTest >> testIncludesAssociation [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self
+			deny: (dictionary includesAssociation: each);
+			deny: (dictionary includesAssociation: each key -> each value).
+
+		dictionary add: each.
+		self
+			assert: (dictionary includesAssociation: each);
+			assert: (dictionary includesAssociation: each key -> each value)]
+]
+
+{ #category : #'tests - testing' }
+OrderedDictionaryExtensionsTest >> testIncludesIdentity [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self deny: (dictionary includesIdentity: each value).
+
+		dictionary add: each.
+		self
+			assert: (dictionary includesIdentity: each value);
+			deny: (dictionary includesIdentity: each value copy)]
+]
+
+{ #category : #'tests - testing' }
+OrderedDictionaryExtensionsTest >> testIncludesKey [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self deny: (dictionary includesKey: each key).
+
+		dictionary add: each.
+		self assert: (dictionary includesKey: each key)]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testIndexOfKey [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert: (dictionary indexOfKey: each key) equals: 0.
+
+		dictionary add: each.
+		self assert: (dictionary indexOfKey: each key) equals: i]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testIndexOfKeyIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				indexOfKey: each key
+				ifAbsent: [self absentValue]) equals: self absentValue.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				indexOfKey: each key
+				ifAbsent: [self fail]) equals: i]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testIsDictionary [
+	self assert: self dictionaryClass new isDictionary
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyAtIdentityValue [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self
+			should: [dictionary keyAtIdentityValue: each value]
+			raise: Error.
+
+		dictionary add: each.
+		self assert: (dictionary keyAtIdentityValue: each value) equals: each key.
+		self
+			should: [dictionary keyAtIdentityValue: each value copy]
+			raise: Error]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyAtIdentityValueIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert:
+			(dictionary
+				keyAtIdentityValue: each value
+				ifAbsent: [self absentKey]) equals: self absentKey.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				keyAtIdentityValue: each value
+				ifAbsent: [self fail]) equals: each key.
+		self assert:
+			(dictionary
+				keyAtIdentityValue: each value copy
+				ifAbsent: [self absentKey]) equals: self absentKey]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyAtIndex [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		should: [dictionary keyAtIndex: 0]
+		raise: Error.
+	self orderedAssociations withIndexDo: [:each :i |
+		self
+			should: [dictionary keyAtIndex: i]
+			raise: Error.
+
+		dictionary add: each.
+		self assert: (dictionary keyAtIndex: i) equals: each key]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyAtIndexIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self assert:
+		(dictionary
+			keyAtIndex: 0
+			ifAbsent: [self absentKey]) equals: self absentKey.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				keyAtIndex: i
+				ifAbsent: [self absentKey]) equals: self absentKey.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				keyAtIndex: i
+				ifAbsent: [self fail]) equals: each key]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyAtValue [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self
+			should: [dictionary keyAtValue: each value]
+			raise: Error.
+
+		dictionary add: each.
+		self assert: (dictionary keyAtValue: each value) equals: each key]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyAtValueIfAbsent [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert:
+			(dictionary
+				keyAtValue: each value
+				ifAbsent: [self absentKey]) equals: self absentKey.
+
+		dictionary add: each.
+		self assert:
+			(dictionary
+				keyAtValue: each value
+				ifAbsent: [self fail]) equals: each key]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeyForIdentity [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations do: [:each |
+		self assert: (dictionary keyForIdentity: each value) isNil.
+
+		dictionary add: each.
+		self
+			assert: (dictionary keyForIdentity: each value) equals: each key;
+			assert: (dictionary keyForIdentity: each value copy) isNil]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testKeys [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		assertIsArray: dictionary keys
+		withElements: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			assertIsArray: dictionary keys
+			withElements: (self orderedKeysFirst: i)]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testKeysAndValuesDo [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		should: [:block | dictionary keysAndValuesDo: block]
+		enumerate: #()
+		and: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			should: [:block | dictionary keysAndValuesDo: block]
+			enumerate: (self orderedKeysFirst: i)
+			and: (self orderedValuesFirst: i)]
+]
+
+{ #category : #'tests - removing' }
+OrderedDictionaryExtensionsTest >> testKeysAndValuesRemove [
+	| dictionary |
+	dictionary := self dictionaryWithOrderedAssociations.
+	self orderedAssociations
+		withIndexDo: [ :removedAssociation :i |
+			| unremovedAssociations |
+			unremovedAssociations := (self orderedAssociationsAllButFirst: i) asOrderedCollection.
+			dictionary
+				keysAndValuesRemove: [ :key :value |
+					(self isTestingIdentityDictionary ifTrue: [ key == removedAssociation key ] ifFalse: [ key = removedAssociation key ])
+						ifTrue: [ self assert: value equals: removedAssociation value.
+							true ]
+						ifFalse: [ | unremovedAssociation |
+							unremovedAssociation := unremovedAssociations removeFirst.
+							self isTestingIdentityDictionary
+								ifTrue: [ self assert: key identicalTo: unremovedAssociation key ]
+								ifFalse: [ self assert: key equals: unremovedAssociation key ].
+							self assert: value equals: unremovedAssociation value.
+							false ] ].
+			self assertEmpty: unremovedAssociations.
+			self assertKey: removedAssociation key wasRemovedfrom: dictionary ].
+	self assertEmpty: dictionary
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testKeysDo [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		should: [:block | dictionary keysDo: block]
+		enumerate: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			should: [:block | dictionary keysDo: block]
+			enumerate: (self orderedKeysFirst: i)]
+]
+
+{ #category : #'tests - creation' }
+OrderedDictionaryExtensionsTest >> testNewFrom [
+	| dictionary |
+
+	dictionary := self dictionaryClass newFrom: self orderedAssociations.
+	self
+		assertIsDictionary: dictionary
+		withOrderedAssociations: self orderedAssociations.
+	self
+		assertIsDictionary: (self dictionaryClass newFrom: dictionary)
+		copiedFrom: dictionary
+		withOrderedAssociations: self orderedAssociations.
+	self
+		assertIsDictionary:
+			(self dictionaryClass newFrom: self internalDictionaryWithAssociations)
+		withUnorderedAssociations: self orderedAssociations
+]
+
+{ #category : #'tests - creation' }
+OrderedDictionaryExtensionsTest >> testNewFromKeysAndValues [ 
+
+	| dict newDict |
+	dict := self dictionaryClass new
+	       at: #a put: 1;
+			 at: #b put: 2;
+			 at: #c put: 3; yourself.
+	newDict := self dictionaryClass newFromKeys: dict keys andValues: dict values.
+	dict keysAndValuesDo: [:k :v|
+		self assert: (newDict at: k) equals: v ]
+]
+
+{ #category : #'tests - creation' }
+OrderedDictionaryExtensionsTest >> testNewFromPairs [
+	| pairs |
+
+	pairs := OrderedCollection new.
+	self orderedAssociations do: [:each |
+		pairs
+			addLast: each key;
+			addLast: each value].
+
+	0 to: pairs size do: [:i |
+		self
+			assertIsDictionary:
+				(self dictionaryClass newFromPairs: (pairs copyFrom: 1 to: i))
+			withOrderedAssociations:
+				(self orderedAssociationsFirst: (i / 2) floor)]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testOccurrencesOf [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self assert: (dictionary occurrencesOf: self newValue) equals: 0.
+	self orderedKeys withIndexDo: [:each :i |
+		dictionary
+			at: each
+			put: self newValue.
+		self assert: (dictionary occurrencesOf: self newValue) equals: i]
+]
+
+{ #category : #'tests - removing' }
+OrderedDictionaryExtensionsTest >> testRemoveAll [
+	| dictionary removedKeys |
+	dictionary := self dictionaryWithOrderedAssociations.
+	removedKeys := dictionary keys.
+	self
+		denyEmpty: dictionary;
+		assert: dictionary removeAll identicalTo: dictionary;
+		assertEmpty: dictionary.
+	removedKeys do: [ :each | self assertKey: each wasRemovedfrom: dictionary ]
+]
+
+{ #category : #'tests - removing' }
+OrderedDictionaryExtensionsTest >> testRemoveKey [
+	| dictionary |
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert: (dictionary removeKey: each key) equals: each value.
+		self
+			assertKey: each key
+			wasRemovedfrom: dictionary.
+		self
+			assertIsDictionary: dictionary
+			withOrderedAssociations: (self orderedAssociationsAllButFirst: i).
+
+		self
+			should: [dictionary removeKey: each key]
+			raise: Error]
+]
+
+{ #category : #'tests - removing' }
+OrderedDictionaryExtensionsTest >> testRemoveKeyIfAbsent [
+	| dictionary |
+	dictionary := self dictionaryWithOrderedAssociations.
+	self orderedAssociations
+		withIndexDo: [ :each :i |
+			self assert: (dictionary removeKey: each key ifAbsent: [ self fail ]) equals: each value.
+			self assertKey: each key wasRemovedfrom: dictionary.
+			self assertIsDictionary: dictionary withOrderedAssociations: (self orderedAssociationsAllButFirst: i).
+
+			self assert: (dictionary removeKey: each key ifAbsent: [ self absentValue ]) equals: self absentValue ]
+]
+
+{ #category : #'tests - removing' }
+OrderedDictionaryExtensionsTest >> testRemoveKeys [
+	0 to: self orderedAssociations size do: [ :i |
+		| dictionary keysToRemove |
+		dictionary := self dictionaryWithOrderedAssociations.
+
+		"make it a set to ensure it supports non-Sequenceable collections"
+		keysToRemove := (self isTestingIdentityDictionary ifTrue: [ IdentitySet ] ifFalse: [ Set ]) withAll: (self orderedKeysFirst: i).
+		self assert: (dictionary removeKeys: keysToRemove) identicalTo: dictionary.
+		keysToRemove do: [ :each | self assertKey: each wasRemovedfrom: dictionary ].
+
+		self assertIsDictionary: dictionary withOrderedAssociations: (self orderedAssociationsAllButFirst: i) ]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testSelect [
+	| dictionary |
+
+	dictionary := self dictionaryWithOrderedAssociations.
+	self orderedValues do: [:value | | selectedValues |
+		selectedValues := self orderedValues copyWithout: value.
+		self
+			assertIsDictionary:
+				(dictionary select: [:each |
+					selectedValues includes: each])
+			copiedFrom: dictionary
+			withOrderedAssociations:
+				(self orderedAssociations select: [:each |
+					selectedValues includes: each value])]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testSize [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self assert: dictionary size equals: 0.
+
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self assert: dictionary size equals: i].
+
+	self orderedAssociations size to: 1 by: -1 do: [:i |
+		dictionary removeKey: (self orderedKeys at: i).
+		self assert: dictionary size equals: (i - 1)]
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testStoreOn [
+	| print |
+	print := String streamContents: [ :s | self orderedAssociations storeOn: s ].
+	self assertDictionary: (self class compiler evaluate: print) equals: self orderedAssociations.
+	print := String streamContents: [ :s | self emptyDictionary storeOn: s ].
+	self assertDictionary: (self class compiler evaluate: print) equals: self emptyDictionary
+]
+
+{ #category : #'tests - accessing' }
+OrderedDictionaryExtensionsTest >> testValues [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		assertIsArray: dictionary values
+		withElements: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			assertIsArray: dictionary values
+			withElements: (self orderedValuesFirst: i)]
+]
+
+{ #category : #'tests - enumerating' }
+OrderedDictionaryExtensionsTest >> testValuesDo [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self
+		should: [:block | dictionary valuesDo: block]
+		enumerate: #().
+	self orderedAssociations withIndexDo: [:each :i |
+		dictionary add: each.
+		self
+			should: [:block | dictionary valuesDo: block]
+			enumerate: (self orderedValuesFirst: i)]
+]

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -118,7 +118,7 @@ OrderedDictionaryExtensionsTest >> changedOrderedAssociations [
 { #category : #accessing }
 OrderedDictionaryExtensionsTest >> changedOrderedAssociationsFirst: anInteger [
 
-	^ self changedOrderedAssociations first: anInteger
+	^ self changedOrderedAssociations copyFirst: anInteger
 ]
 
 { #category : #accessing }
@@ -250,7 +250,7 @@ OrderedDictionaryExtensionsTest >> orderedAssociationsAllButFirst: anInteger [
 { #category : #accessing }
 OrderedDictionaryExtensionsTest >> orderedAssociationsFirst: anInteger [
 
-	^ self orderedAssociations first: anInteger
+	^ self orderedAssociations copyFirst: anInteger
 ]
 
 { #category : #accessing }
@@ -262,7 +262,7 @@ OrderedDictionaryExtensionsTest >> orderedKeys [
 { #category : #accessing }
 OrderedDictionaryExtensionsTest >> orderedKeysFirst: anInteger [
 
-	^ self orderedKeys first: anInteger
+	^ self orderedKeys copyFirst: anInteger
 ]
 
 { #category : #accessing }
@@ -274,7 +274,7 @@ OrderedDictionaryExtensionsTest >> orderedValues [
 { #category : #accessing }
 OrderedDictionaryExtensionsTest >> orderedValuesFirst: anInteger [
 
-	^ self orderedValues first: anInteger
+	^ self orderedValues copyFirst: anInteger
 ]
 
 { #category : #accessing }
@@ -684,7 +684,7 @@ OrderedDictionaryExtensionsTest >> testDeclareFrom [
 	otherDictionary := self dictionaryWithOrderedAssociations.
 	self orderedKeys do: [ :each | self assert: (dictionary declare: each from: otherDictionary) identicalTo: dictionary ].
 	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations.
-	self assertEmpty: otherDictionary.
+	self assert: otherDictionary isEmpty.
 
 	self orderedKeys
 		do: [ :each |
@@ -1079,9 +1079,9 @@ OrderedDictionaryExtensionsTest >> testKeysAndValuesRemove [
 								ifFalse: [ self assert: key equals: unremovedAssociation key ].
 							self assert: value equals: unremovedAssociation value.
 							false ] ].
-			self assertEmpty: unremovedAssociations.
+			self assert: unremovedAssociations isEmpty.
 			self assertKey: removedAssociation key wasRemovedfrom: dictionary ].
-	self assertEmpty: dictionary
+	self assert: dictionary isEmpty
 ]
 
 { #category : #'tests - enumerating' }
@@ -1163,14 +1163,16 @@ OrderedDictionaryExtensionsTest >> testOccurrencesOf [
 
 { #category : #'tests - removing' }
 OrderedDictionaryExtensionsTest >> testRemoveAll [
+
 	| dictionary removedKeys |
 	dictionary := self dictionaryWithOrderedAssociations.
 	removedKeys := dictionary keys.
 	self
-		denyEmpty: dictionary;
+		deny: dictionary isEmpty;
 		assert: dictionary removeAll identicalTo: dictionary;
-		assertEmpty: dictionary.
-	removedKeys do: [ :each | self assertKey: each wasRemovedfrom: dictionary ]
+		assert: dictionary isEmpty.
+	removedKeys do: [ :each |
+		self assertKey: each wasRemovedfrom: dictionary ]
 ]
 
 { #category : #'tests - removing' }
@@ -1250,15 +1252,6 @@ OrderedDictionaryExtensionsTest >> testSize [
 	self orderedAssociations size to: 1 by: -1 do: [:i |
 		dictionary removeKey: (self orderedKeys at: i).
 		self assert: dictionary size equals: (i - 1)]
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testStoreOn [
-	| print |
-	print := String streamContents: [ :s | self orderedAssociations storeOn: s ].
-	self assertDictionary: (self class compiler evaluate: print) equals: self orderedAssociations.
-	print := String streamContents: [ :s | self emptyDictionary storeOn: s ].
-	self assertDictionary: (self class compiler evaluate: print) equals: self emptyDictionary
 ]
 
 { #category : #'tests - accessing' }

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -850,17 +850,17 @@ OrderedDictionaryExtensionsTest >> testIncludesAssociation [
 ]
 
 { #category : #'tests - testing' }
-OrderedDictionaryExtensionsTest >> testIncludesIdentity [
-	| dictionary |
+OrderedDictionaryExtensionsTest >> testIncludesIdenticalTo [
 
+	| dictionary |
 	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
-		self deny: (dictionary includesIdentity: each value).
+	self orderedAssociations do: [ :each |
+		self deny: (dictionary includesIdenticalTo: each value).
 
 		dictionary add: each.
 		self
-			assert: (dictionary includesIdentity: each value);
-			deny: (dictionary includesIdentity: each value copy)]
+			assert: (dictionary includesIdenticalTo: each value);
+			deny: (dictionary includesIdenticalTo: each value copy) ]
 ]
 
 { #category : #'tests - testing' }
@@ -908,23 +908,6 @@ OrderedDictionaryExtensionsTest >> testIndexOfKeyIfAbsent [
 { #category : #'tests - accessing' }
 OrderedDictionaryExtensionsTest >> testIsDictionary [
 	self assert: self dictionaryClass new isDictionary
-]
-
-{ #category : #'tests - accessing' }
-OrderedDictionaryExtensionsTest >> testKeyAtIndex [
-	| dictionary |
-
-	dictionary := self emptyDictionary.
-	self
-		should: [dictionary keyAtIndex: 0]
-		raise: Error.
-	self orderedAssociations withIndexDo: [:each :i |
-		self
-			should: [dictionary keyAtIndex: i]
-			raise: Error.
-
-		dictionary add: each.
-		self assert: (dictionary keyAtIndex: i) equals: each key]
 ]
 
 { #category : #'tests - accessing' }

--- a/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/OrderedDictionaryExtensionsTest.class.st
@@ -12,14 +12,6 @@ Class {
 }
 
 { #category : #accessing }
-OrderedDictionaryExtensionsTest >> absentKey [
-
-	^self isTestingIdentityDictionary
-		ifTrue: [ self identityAbsentKey ]
-		ifFalse: [ self nonIdentityAbsentKey ]
-]
-
-{ #category : #accessing }
 OrderedDictionaryExtensionsTest >> absentValue [
 	^ 'absentValue'
 ]
@@ -80,18 +72,14 @@ OrderedDictionaryExtensionsTest >> assertIsDictionary: anObject withOrderedAssoc
 	self
 		assert: anObject class identicalTo: self dictionaryClass;
 		assert: anObject orderedKeys size >= anAssociationCollection size;
-		assert: anObject associations size equals: anAssociationCollection size.
+		assert: anObject associations size
+		equals: anAssociationCollection size.
 
-	anAssociationCollection
-		withIndexDo: [ :each :i |
-			self isTestingIdentityDictionary
-				ifTrue: [ self
-						assert: (anObject orderedKeys at: i) identicalTo: each key;
-						assert: (anObject associations at: i) key identicalTo: each key ]
-				ifFalse: [ self
-						assert: (anObject orderedKeys at: i) equals: each key;
-						assert: (anObject associations at: i) key equals: each key ].
-			self assert: (anObject associations at: i) value equals: each value ]
+	anAssociationCollection withIndexDo: [ :each :i |
+		self
+			assert: (anObject orderedKeys at: i) equals: each key;
+			assert: (anObject associations at: i) key equals: each key;
+			assert: (anObject associations at: i) value equals: each value ]
 ]
 
 { #category : #assertions }
@@ -109,11 +97,8 @@ OrderedDictionaryExtensionsTest >> assertIsDictionary: anObject withUnorderedAss
 OrderedDictionaryExtensionsTest >> assertKey: aKey wasRemovedfrom: aDictionary [
 
 	self deny: (aDictionary includesKey: aKey).
-	aDictionary keys asArray, aDictionary orderedKeys asArray do: [:each |
-		self deny:
-			(self isTestingIdentityDictionary
-				ifTrue: [each == aKey]
-				ifFalse: [each = aKey])]
+	aDictionary keys asArray , aDictionary orderedKeys asArray do: [
+		:each | self deny: each equals: aKey ]
 ]
 
 { #category : #accessing }
@@ -126,12 +111,6 @@ OrderedDictionaryExtensionsTest >> changedOrderedAssociations [
 OrderedDictionaryExtensionsTest >> changedOrderedAssociationsFirst: anInteger [
 
 	^ self changedOrderedAssociations copyFirst: anInteger
-]
-
-{ #category : #accessing }
-OrderedDictionaryExtensionsTest >> collectClass [
-
-	^ Array
 ]
 
 { #category : #accessing }
@@ -165,37 +144,9 @@ OrderedDictionaryExtensionsTest >> emptyInternalDictionary [
 ]
 
 { #category : #accessing }
-OrderedDictionaryExtensionsTest >> identityAbsentKey [
-
-	^ self orderedKeys first copy
-]
-
-{ #category : #accessing }
-OrderedDictionaryExtensionsTest >> identityOrderedAssociations [
-	"Returns ordered associations to use for identity dictionaries.
-	The keys are all #= equal but #== different, so only an
-	identity dictionary will be able to distinguish them."
-	identityOrderedAssociations
-		ifNil: [| key |
-			key := 'testKey'.
-			identityOrderedAssociations :=
-				Array
-					with: (key := key copy) -> 'testValue'
-					with: (key := key copy) -> 'testValue3'
-					with: (key := key copy) -> 'testValue2'
-					with: (key := key copy) -> 'testValue4'].
-	"Return copies of the associations so they can be safely modified
-	in one test without affecting another, but do not copy the keys
-	and values"
-	^ identityOrderedAssociations collect: [:each | each copy]
-]
-
-{ #category : #accessing }
 OrderedDictionaryExtensionsTest >> internalDictionaryClass [
 
-	^self isTestingIdentityDictionary
-		ifTrue: [ IdentityDictionary]
-		ifFalse: [ Dictionary]
+	^ Dictionary
 ]
 
 { #category : #accessing }
@@ -204,22 +155,10 @@ OrderedDictionaryExtensionsTest >> internalDictionaryWithAssociations [
 	^ self internalDictionaryClass newFrom: self orderedAssociations
 ]
 
-{ #category : #testing }
-OrderedDictionaryExtensionsTest >> isTestingIdentityDictionary [
-
-	^ false
-]
-
 { #category : #accessing }
 OrderedDictionaryExtensionsTest >> newValue [
 
 	^ 'newValue'
-]
-
-{ #category : #accessing }
-OrderedDictionaryExtensionsTest >> nonIdentityAbsentKey [
-
-	^ 'absentKey'
 ]
 
 { #category : #accessing }
@@ -243,9 +182,8 @@ OrderedDictionaryExtensionsTest >> nonIdentityOrderedAssociations [
 
 { #category : #accessing }
 OrderedDictionaryExtensionsTest >> orderedAssociations [
-	^self isTestingIdentityDictionary
-		ifTrue: [ self identityOrderedAssociations ]
-		ifFalse: [ self nonIdentityOrderedAssociations ]
+
+	^ self nonIdentityOrderedAssociations
 ]
 
 { #category : #accessing }
@@ -282,12 +220,6 @@ OrderedDictionaryExtensionsTest >> orderedValues [
 OrderedDictionaryExtensionsTest >> orderedValuesFirst: anInteger [
 
 	^ self orderedValues copyFirst: anInteger
-]
-
-{ #category : #accessing }
-OrderedDictionaryExtensionsTest >> otherOrderedDictionaryClasses [
-
-	^ OrderedDictionary withAllSubclasses copyWithout: self dictionaryClass
 ]
 
 { #category : #assertions }
@@ -921,26 +853,26 @@ OrderedDictionaryExtensionsTest >> testKeysAndValuesDo [
 
 { #category : #'tests - removing' }
 OrderedDictionaryExtensionsTest >> testKeysAndValuesRemove [
+
 	| dictionary |
 	dictionary := self dictionaryWithOrderedAssociations.
-	self orderedAssociations
-		withIndexDo: [ :removedAssociation :i |
-			| unremovedAssociations |
-			unremovedAssociations := (self orderedAssociationsAllButFirst: i) asOrderedCollection.
-			dictionary
-				keysAndValuesRemove: [ :key :value |
-					(self isTestingIdentityDictionary ifTrue: [ key == removedAssociation key ] ifFalse: [ key = removedAssociation key ])
-						ifTrue: [ self assert: value equals: removedAssociation value.
-							true ]
-						ifFalse: [ | unremovedAssociation |
-							unremovedAssociation := unremovedAssociations removeFirst.
-							self isTestingIdentityDictionary
-								ifTrue: [ self assert: key identicalTo: unremovedAssociation key ]
-								ifFalse: [ self assert: key equals: unremovedAssociation key ].
-							self assert: value equals: unremovedAssociation value.
-							false ] ].
-			self assert: unremovedAssociations isEmpty.
-			self assertKey: removedAssociation key wasRemovedfrom: dictionary ].
+	self orderedAssociations withIndexDo: [ :removedAssociation :i |
+		| unremovedAssociations |
+		unremovedAssociations := (self orderedAssociationsAllButFirst: i)
+			                         asOrderedCollection.
+		dictionary keysAndValuesRemove: [ :key :value |
+			key = removedAssociation key
+				ifTrue: [
+					self assert: value equals: removedAssociation value.
+					true ]
+				ifFalse: [
+					| unremovedAssociation |
+					unremovedAssociation := unremovedAssociations removeFirst.
+					self assert: key equals: unremovedAssociation key.
+					self assert: value equals: unremovedAssociation value.
+					false ] ].
+		self assert: unremovedAssociations isEmpty.
+		self assertKey: removedAssociation key wasRemovedfrom: dictionary ].
 	self assert: dictionary isEmpty
 ]
 
@@ -1069,16 +1001,22 @@ OrderedDictionaryExtensionsTest >> testRemoveKeyIfAbsent [
 
 { #category : #'tests - removing' }
 OrderedDictionaryExtensionsTest >> testRemoveKeys [
+
 	0 to: self orderedAssociations size do: [ :i |
 		| dictionary keysToRemove |
 		dictionary := self dictionaryWithOrderedAssociations.
 
 		"make it a set to ensure it supports non-Sequenceable collections"
-		keysToRemove := (self isTestingIdentityDictionary ifTrue: [ IdentitySet ] ifFalse: [ Set ]) withAll: (self orderedKeysFirst: i).
-		self assert: (dictionary removeKeys: keysToRemove) identicalTo: dictionary.
-		keysToRemove do: [ :each | self assertKey: each wasRemovedfrom: dictionary ].
+		keysToRemove := Set withAll: (self orderedKeysFirst: i).
+		self
+			assert: (dictionary removeKeys: keysToRemove)
+			identicalTo: dictionary.
+		keysToRemove do: [ :each |
+			self assertKey: each wasRemovedfrom: dictionary ].
 
-		self assertIsDictionary: dictionary withOrderedAssociations: (self orderedAssociationsAllButFirst: i) ]
+		self
+			assertIsDictionary: dictionary
+			withOrderedAssociations: (self orderedAssociationsAllButFirst: i) ]
 ]
 
 { #category : #'tests - enumerating' }

--- a/source/Buoy-Collections-Tests/StreamExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/StreamExtensionsTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #StreamExtensionsTest,
+	#superclass : #TestCase,
+	#category : #'Buoy-Collections-Tests'
+}
+
+{ #category : #tests }
+StreamExtensionsTest >> testIsBinary [
+
+	self
+		assert: #[ 1 2 ] readStream isBinary;
+		deny: '123' readStream isBinary;
+		deny: #(  ) readStream isBinary;
+		assert: #[ 1 2 ] writeStream isBinary;
+		deny: '123' writeStream isBinary;
+		deny: #(  ) writeStream isBinary
+]

--- a/source/Buoy-Collections-Tests/StringExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/StringExtensionsTest.class.st
@@ -5,6 +5,23 @@ Class {
 }
 
 { #category : #tests }
+StringExtensionsTest >> testCr [
+
+	self
+		assert: String cr
+		equals: (String streamContents: [ :stream | stream cr ])
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testCrlf [
+
+	self assert: String crlf equals: (String streamContents: [ :stream |
+			 stream
+				 cr;
+				 lf ])
+]
+
+{ #category : #tests }
 StringExtensionsTest >> testExpandMacros [
 
 	self
@@ -42,4 +59,12 @@ StringExtensionsTest >> testExpandMacrosWithArguments [
 		equals: '''str''''ing''';
 		assert: ('<1p>: <2p>' expandMacrosWith: 'Number' with: 5)
 		equals: '''Number'': 5'
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testLf [
+
+	self
+		assert: String lf
+		equals: (String streamContents: [ :stream | stream lf ])
 ]

--- a/source/Buoy-GS64-Compatibility/GsSocket.class.st
+++ b/source/Buoy-GS64-Compatibility/GsSocket.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #GsSocket,
+	#superclass : #Object,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-Math-GS64-Base-Extensions/DomainError.class.st
+++ b/source/Buoy-Math-GS64-Base-Extensions/DomainError.class.st
@@ -1,0 +1,72 @@
+"
+I am DomainError, an ArithmeticException indicating that some argument falls outside an expected domain, [from, to]
+
+When my valid interval is left- or right-open, use signal: creation protocol to provide a custom messageText rather than the default [from, to] notation.
+"
+Class {
+	#name : #DomainError,
+	#superclass : #ArithmeticError,
+	#instVars : [
+		'from',
+		'to'
+	],
+	#category : #'Buoy-Math-GS64-Base-Extensions'
+}
+
+{ #category : #signaling }
+DomainError class >> signal: signallerText from: start [
+	^ self signal: signallerText from: start to: Float infinity
+]
+
+{ #category : #signaling }
+DomainError class >> signal: signallerText from: start to: end [
+	^ self new
+		from: start;
+		to: end;
+		signal: signallerText
+]
+
+{ #category : #signaling }
+DomainError class >> signal: signallerText to: end [
+	^ self signal: signallerText from: Float infinity negated to: end
+]
+
+{ #category : #signaling }
+DomainError class >> signalFrom: start [
+	^ self signalFrom: start to: Float infinity
+]
+
+{ #category : #signaling }
+DomainError class >> signalFrom: start to: end [
+	| msgStart msgEnd |
+	msgStart := (start isFloat and: [start isFinite not]) ifTrue: ['(-infinity'] ifFalse: ['[', start printString].
+	msgEnd := (end isFloat and: [end isFinite not]) ifTrue: ['infinity)'] ifFalse: [end printString, ']'].
+	^ self signal: 'Value outside ', msgStart, ' , ' , msgEnd
+		from: start
+		to: end
+]
+
+{ #category : #signaling }
+DomainError class >> signalTo: end [
+	^ self signalFrom: Float infinity negated to: end
+]
+
+{ #category : #accessing }
+DomainError >> from [
+	^ from
+]
+
+{ #category : #accessing }
+DomainError >> from: start [
+	from := start
+]
+
+{ #category : #accessing }
+DomainError >> to [
+	^ to
+]
+
+{ #category : #accessing }
+DomainError >> to: end [
+	to := end
+]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
@@ -28,8 +28,8 @@ DynamicVariable class >> value: anObject during: aBlock [
 	oldValue := activeProcess
 		            environmentAt: self
 		            ifAbsent: [ self default ].
-	[
-	activeProcess environmentAt: self put: anObject.
-	aBlock value ] ensure: [
-		activeProcess environmentAt: self put: oldValue ]
+	^ [
+	  activeProcess environmentAt: self put: anObject.
+	  aBlock value ] ensure: [
+		  activeProcess environmentAt: self put: oldValue ]
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #DynamicVariable,
+	#superclass : #Object,
+	#category : #'Buoy-Metaprogramming-GS64-Extensions'
+}
+
+{ #category : #accessing }
+DynamicVariable class >> default [
+	"Answer the default value for the variable. The default for the default value is nil."
+
+	^ nil
+]
+
+{ #category : #evaluating }
+DynamicVariable class >> value [
+	"Answer the current value for this variable in the current context."
+
+	^ Processor activeProcess
+		  environmentAt: self
+		  ifAbsent: [ self default ]
+]
+
+{ #category : #evaluating }
+DynamicVariable class >> value: anObject during: aBlock [
+
+	| activeProcess oldValue |
+	activeProcess := Processor activeProcess.
+	oldValue := activeProcess
+		            environmentAt: self
+		            ifAbsent: [ self default ].
+	[
+	activeProcess environmentAt: self put: anObject.
+	aBlock value ] ensure: [
+		activeProcess environmentAt: self put: oldValue ]
+]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/Object.extension.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/Object.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #Object }
 
 { #category : #'*Buoy-Metaprogramming-GS64-Extensions' }
+Object >> assert: aBlock [
+
+	aBlock value == true ifFalse: [
+		AssertionFailed signal: 'Assertion failed' ]
+]
+
+{ #category : #'*Buoy-Metaprogramming-GS64-Extensions' }
 Object class >> new [
 
 	^ super new initialize

--- a/source/Buoy-Metaprogramming-GS64-Extensions/Object.extension.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/Object.extension.st
@@ -3,8 +3,14 @@ Extension { #name : #Object }
 { #category : #'*Buoy-Metaprogramming-GS64-Extensions' }
 Object >> assert: aBlock [
 
+	self assert: aBlock description: 'Assertion failed'
+]
+
+{ #category : #'*Buoy-Metaprogramming-GS64-Extensions' }
+Object >> assert: aBlock description: aBlockOrString [
+
 	aBlock value == true ifFalse: [
-		AssertionFailed signal: 'Assertion failed' ]
+		AssertionFailed signal: aBlockOrString value ]
 ]
 
 { #category : #'*Buoy-Metaprogramming-GS64-Extensions' }

--- a/source/Buoy-Metaprogramming-Tests/DynamicVariableForTesting.class.st
+++ b/source/Buoy-Metaprogramming-Tests/DynamicVariableForTesting.class.st
@@ -9,3 +9,9 @@ DynamicVariableForTesting class >> default [
 
 	^ 3
 ]
+
+{ #category : #accessing }
+DynamicVariableForTesting >> default [
+
+	^ self class default
+]

--- a/source/Buoy-Metaprogramming-Tests/DynamicVariableForTesting.class.st
+++ b/source/Buoy-Metaprogramming-Tests/DynamicVariableForTesting.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #DynamicVariableForTesting,
+	#superclass : #DynamicVariable,
+	#category : #'Buoy-Metaprogramming-Tests'
+}
+
+{ #category : #accessing }
+DynamicVariableForTesting class >> default [
+
+	^ 3
+]

--- a/source/Buoy-Metaprogramming-Tests/DynamicVariableTest.class.st
+++ b/source/Buoy-Metaprogramming-Tests/DynamicVariableTest.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : #DynamicVariableTest,
+	#superclass : #TestCase,
+	#category : #'Buoy-Metaprogramming-Tests'
+}
+
+{ #category : #tests }
+DynamicVariableTest >> testDynamicVariableBlockReturnValue [
+
+	| returnValue |
+	returnValue := DynamicVariableForTesting
+		               value: 10
+		               during: [ DynamicVariableForTesting value + 1 ].
+	self assert: returnValue equals: 11
+]
+
+{ #category : #tests }
+DynamicVariableTest >> testDynamicVariableDefault [
+
+	self
+		assert: DynamicVariableForTesting default equals: 3;
+		assert: DynamicVariableForTesting value equals: 3
+]
+
+{ #category : #tests }
+DynamicVariableTest >> testDynamicVariableRemovedAfterUse [
+
+	DynamicVariableForTesting value: 8 during: [  ].
+
+	self
+		assert: DynamicVariableForTesting default equals: 3;
+		assert: DynamicVariableForTesting value equals: 3
+]

--- a/source/Buoy-Metaprogramming-Tests/DynamicVariableTest.class.st
+++ b/source/Buoy-Metaprogramming-Tests/DynamicVariableTest.class.st
@@ -18,7 +18,7 @@ DynamicVariableTest >> testDynamicVariableBlockReturnValue [
 DynamicVariableTest >> testDynamicVariableDefault [
 
 	self
-		assert: DynamicVariableForTesting default equals: 3;
+		assert: DynamicVariableForTesting new default equals: 3;
 		assert: DynamicVariableForTesting value equals: 3
 ]
 


### PR DESCRIPTION
- Alias `KeyNotFound` to the equivalent exception on GS/64
- Add `Collection>>#includesIdenticalTo:`
- Add `AbstractDictionary>>#at:ifPresent:ifAbsent:`
- Add `AbstractDictionary class>>#newFromPairs:`
- Add `isArray`
- Add `CharacterCollection class>>#cr` and `CharacterCollection class>>#lf`
- Add `OrderedDictionary`
- Add `PositionableStream>>#isBinary`
- Add `DomainError`
- Add `DynamicVariable`
- Add `Object>>#assert:` and `Object>>#assert:description:`