### PR TITLE
Add missing extensions and classes for GS64

### DIFF
--- a/docs/reference/Baseline-groups.md
+++ b/docs/reference/Baseline-groups.md
@@ -14,11 +14,22 @@ loading targets:
 - `Development` will load all the needed packages to develop and contribute to
    the project
 
-- `GS64-Development` is an optional group that will load `Development` and all
-  the packages required to develop changes applicable to GS64. Loading this package
-  will make dirty other packages in the project but this is expected, just remember
-  to cherry-pick the changes to commit and don't remove the changed methods in the
-  Pharo package.
+## Pharo - GS64 Development glue
+
+`GS64-Development` is an optional group that will load `Development` and all
+the packages required to develop changes applicable to GS64 in a Pharo image.
+
+Loading this package can have unexpected consequences on to the Pharo image,
+because it extends and changes some kernel classes. To load this group you will
+need first to rename `DynamicVariable` to another thing because it will try to
+load a GS64 version of it, and it's used during the loading stage.
+
+Once the packages are loaded remove the extension in `Object class>>#new`
+to recover the cursor in the browsers.
+
+Other packages in the project will be marked as dirty, but this is expected;
+just remember to cherry-pick the changes to commit and don't remove the changed
+methods in the Pharo related packages.
 
 ## GS64 Components
 

--- a/docs/reference/Collections.md
+++ b/docs/reference/Collections.md
@@ -31,9 +31,12 @@ Some examples
 - `detect:ifFound:ifNone:` evaluates an action block if any of the elements match
   the condition block. If no elements match evaluates the fail block.
 - `ifEmpty:ifNotEmpty:` evaluates one of two blocks depending on the collection emptiness.
+- `noneSatisfy:` evaluates to true if no one in the collection satisfies the condition.
+- `printElementsOn:` prints the elements in the collection to a string.
 - `removeAll` removes all elements of the receiver.
 - `select:thenCollect:` filters the elements in the receiver using the condition
   block, collecting after the results evaluating the action block.
+- `sorted` returns a copy of the collection sorted.
 
 ## `SequenceableCollection` extensions
 
@@ -87,12 +90,15 @@ Some examples
 - `copyAfter:` returns a copy of the receiver after the first occurrence
   of the argument up to the end, or empty if no element matches.
 - `endsWith:` returns true if the argument is a suffix of the receiver.
+- `pairsDo:` evaluates the block for each pair of elements in the receiver.
 - `writeStream` returns a write stream over the receiver.
 
 ## `Dictionary` extensions for GS64
 
+- `associations` returns the collection of associations.
 - `at:ifPresent:ifAbsentPut:` lookups a value, if any matches evaluates a block,
   if no one matches put under the key the result o evaluating the second block.
+- `removeAll` removes all elments on the dictionary.
 
 ## `String` extensions for GS64
 
@@ -113,6 +119,13 @@ These methods interpolate the receiver pattern using the provided arguments:
 - `<Ns>` is replaced by the string provided in the nth argument
 - `<N?trueString:falseString>` is replaced by `trueString` or `falseString`
   depending on the boolean provided in the nth argument.
+
+- `findTokens:` returns a collection of the substrings between the delimiters passed as argument.
+- `includesSubstring:` returns true if the receiver includes the argument.
+- `isAllDigits` returns true if all the characters are digits.
+- `lines` returns a collection of the lines in the receiver.
+- `linesDo:` iterates over the lines in the receiver.
+- `withoutQuoting` returns a copy of the receiver trimming any posible quotes.
 
 ## Circular Iterator
 

--- a/docs/reference/Collections.md
+++ b/docs/reference/Collections.md
@@ -120,12 +120,13 @@ These methods interpolate the receiver pattern using the provided arguments:
 - `<N?trueString:falseString>` is replaced by `trueString` or `falseString`
   depending on the boolean provided in the nth argument.
 
-- `findTokens:` returns a collection of the substrings between the delimiters passed as argument.
+- `findTokens:` returns a collection of the substrings between the delimiters
+  passed as argument.
 - `includesSubstring:` returns true if the receiver includes the argument.
 - `isAllDigits` returns true if all the characters are digits.
 - `lines` returns a collection of the lines in the receiver.
 - `linesDo:` iterates over the lines in the receiver.
-- `withoutQuoting` returns a copy of the receiver trimming any posible quotes.
+- `withoutQuoting` returns a copy of the receiver trimming any possible quotes.
 
 ## Circular Iterator
 

--- a/docs/reference/MOP.md
+++ b/docs/reference/MOP.md
@@ -2,9 +2,10 @@
 
 ## `Symbol` extensions for GS64
 
-- `value:` allows to use a unary symbol as a replacement for a unary block
+- `value:` allows using a unary symbol as a replacement for a unary block
 
 ## `Class` extensions for GS64
 
 - `allLeafSubclasses` returns all the subclasses of the receiver that don't
   have further subclasses
+- `allSubclassesDo:` iterates over all the subclasses of the receiver

--- a/docs/reference/Math.md
+++ b/docs/reference/Math.md
@@ -64,5 +64,13 @@ create one is to send the message `perMille` to a number.
 
 - `isInfinite` returns true if the receiver is infinite
 
+## `Integer` Extensions for GS64
+
+- `#printStringHex` prints the receiver in hexadecimal
+- `#printStringLenght:padded:` prints the receiver to a minimum size, optionally padding
+  with zeros.
+- `readFrom:ifFail:` parses an Integer or evaluates the failure block if the format is
+  invalid.
+
 ---
 Some definitions and examples are based on the ones on [Wikipedia](https://en.wikipedia.org/wiki/Percentage)

--- a/docs/reference/Math.md
+++ b/docs/reference/Math.md
@@ -67,10 +67,10 @@ create one is to send the message `perMille` to a number.
 ## `Integer` Extensions for GS64
 
 - `#printStringHex` prints the receiver in hexadecimal
-- `#printStringLenght:padded:` prints the receiver to a minimum size, optionally padding
-  with zeros.
-- `readFrom:ifFail:` parses an Integer or evaluates the failure block if the format is
-  invalid.
+- `#printStringLenght:padded:` prints the receiver to a minimum size,
+  optionally padding with zeros.
+- `readFrom:ifFail:` parses an Integer or evaluates the failure block if the
+  format is invalid.
 
 ---
 Some definitions and examples are based on the ones on [Wikipedia](https://en.wikipedia.org/wiki/Percentage)

--- a/rowan/components/scripts/defineClassAliases.st
+++ b/rowan/components/scripts/defineClassAliases.st
@@ -11,3 +11,5 @@ symbolDictionary at: #KeyNotFound put: LookupError.
 symbolDictionary at: #NotFound put: LookupError.
 symbolDictionary at: #SubscriptOutOfBounds put: OffsetError.
 symbolDictionary at: #SmallDictionary put: Dictionary.
+"Temporary, it will be fixed in a post load script"
+symbolDictionary at: #AssertionFailure put: nil.

--- a/source/BaselineOfBuoy/BaselineOfBuoy.class.st
+++ b/source/BaselineOfBuoy/BaselineOfBuoy.class.st
@@ -28,7 +28,8 @@ BaselineOfBuoy >> baseline: spec [
 				baselineGS64Development: spec.
 			spec
 				group: 'CI' with: 'Tests';
-				group: 'Development' with: #('Tools' 'Tests')
+				group: 'Development' with: #('Tools' 'Tests');
+				group: 'default' with: 'Development'
 			]
 ]
 

--- a/source/Buoy-Chronology-GS64-Extensions/Date.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/Date.extension.st
@@ -1,6 +1,18 @@
 Extension { #name : #Date }
 
 { #category : #'*Buoy-Chronology-GS64-Extensions' }
+Date >> asDateAndTime [
+
+	^ DateAndTime year: self year month: self monthIndex day: self dayOfMonth
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Date class >> year: year month: month day: day [
+
+	^ self newDay: day monthNumber: month year: year
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
 Date >> yyyymmdd [
 	"Format the date in ISO 8601 standard like '2002-10-22'
 	The result is of fixed size 10 characters long."

--- a/source/Buoy-Chronology-GS64-Extensions/DateAndTime.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/DateAndTime.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #DateAndTime }
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+DateAndTime >> asDateAndTime [
+
+	^ self
+]

--- a/source/Buoy-Chronology-GS64-Extensions/DateAndTimeANSI.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/DateAndTimeANSI.extension.st
@@ -1,0 +1,42 @@
+Extension { #name : #DateAndTimeANSI }
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+DateAndTimeANSI >> monthIndex [
+
+	^ self month
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+DateAndTimeANSI >> printHMSOn: aStream [
+
+	aStream
+		nextPutAll: (self hour printStringLength: 2 padded: true);
+		nextPut: $:;
+		nextPutAll: (self minute printStringLength: 2 padded: true);
+		nextPut: $:;
+		nextPutAll: (self second asInteger printStringLength: 2 padded: true)
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+DateAndTimeANSI >> printYMDOn: aStream [
+
+	aStream
+		nextPutAll: (self year printStringLength: 4 padded: true);
+		nextPut: $-;
+		nextPutAll: (self monthIndex printStringLength: 2 padded: true);
+		nextPut: $-;
+		nextPutAll: (self dayOfMonth printStringLength: 2 padded: true)
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+DateAndTimeANSI class >> year: year month: month day: day [
+	"Return a DateAndTime, midnight local time"
+
+	^ self
+		  year: year
+		  month: month
+		  day: day
+		  hour: 0
+		  minute: 0
+		  second: 0
+]

--- a/source/Buoy-Chronology-GS64-Extensions/Duration.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/Duration.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #Duration }
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Duration class >> days: aNumber [
+
+	^ self seconds: aNumber * 86400
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Duration class >> hours: aNumber [
+
+	^ self seconds: aNumber * 3600
+]

--- a/source/Buoy-Chronology-GS64-Extensions/Integer.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/Integer.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #Integer }
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Integer >> day [
+
+ 	^ self days
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Integer >> days [
+
+ 	^ Duration days: self
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Integer >> hour [
+
+ 	^ self hours
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Integer >> hours [
+
+ 	^ Duration hours: self
+]

--- a/source/Buoy-Chronology-GS64-Extensions/Number.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/Number.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #Number }
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Number >> second [
+	"1 second printString >>> '0:00:00:01'"
+	"(1 minute + 1 second) printString >>> '0:00:01:01'"
+
+ 	^ self seconds
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Number >> seconds [
+
+	^ Duration seconds: self
+]

--- a/source/Buoy-Chronology-GS64-Extensions/Time.extension.st
+++ b/source/Buoy-Chronology-GS64-Extensions/Time.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : #Time }
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Time class >> milliseconds: currentTime since: lastTime [
+	"Answer the elapsed time since last recorded in milliseconds.
+	Compensate for rollover."
+
+	| delta |
+	delta := currentTime - lastTime.
+	^ delta < 0
+		ifTrue: [SmallInteger maximumValue + delta]
+		ifFalse: [delta]
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Time class >> millisecondsSince: lastTime [
+ 	"Answer the elapsed time since last recorded in milliseconds.
+ 	Compensate for rollover."
+
+ 	^self milliseconds: self millisecondClockValue since: lastTime
+]
+
+{ #category : #'*Buoy-Chronology-GS64-Extensions' }
+Time class >> totalSeconds [
+	"Answer the total seconds ellapsed since the epoch: 1 January 1901 00:00 UTC"
+
+	^ System timeGmt
+]

--- a/source/Buoy-Chronology-Tests/DateAndTimeExtensionsTest.class.st
+++ b/source/Buoy-Chronology-Tests/DateAndTimeExtensionsTest.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #DateAndTimeExtensionsTest,
+	#superclass : #TestCase,
+	#category : #'Buoy-Chronology-Tests'
+}
+
+{ #category : #tests }
+DateAndTimeExtensionsTest >> testPrintHMS [
+
+	| dateAndTime |
+	dateAndTime := DateAndTime
+		               year: 2023
+		               month: 2
+		               day: 1
+		               hour: 4
+		               minute: 6
+		               second: 1.
+
+	self
+		assert: (String streamContents: [ :s | dateAndTime printHMSOn: s ])
+		equals: '04:06:01'
+]
+
+{ #category : #tests }
+DateAndTimeExtensionsTest >> testPrintYMD [
+
+	| dateAndTime |
+	dateAndTime := DateAndTime
+		               year: 2023
+		               month: 2
+		               day: 1
+		               hour: 4
+		               minute: 6
+		               second: 1.
+
+	self
+		assert: (String streamContents: [ :s | dateAndTime printYMDOn: s ])
+		equals: '2023-02-01'
+]

--- a/source/Buoy-Chronology-Tests/DateExtensionsTest.class.st
+++ b/source/Buoy-Chronology-Tests/DateExtensionsTest.class.st
@@ -5,6 +5,22 @@ Class {
 }
 
 { #category : #tests }
+DateExtensionsTest >> testAsDateAndTime [
+
+	| date dateAndTime |
+	date := Date newDay: 5 monthNumber: 4 year: 2023.
+	dateAndTime := date asDateAndTime.
+
+	self
+		assert: date year equals: dateAndTime year;
+		assert: date monthIndex equals: dateAndTime monthIndex;
+		assert: date dayOfMonth equals: dateAndTime dayOfMonth;
+		assert: dateAndTime hour isZero;
+		assert: dateAndTime minute isZero;
+		assert: dateAndTime second isZero
+]
+
+{ #category : #tests }
 DateExtensionsTest >> testCreation [
 
 	| date |

--- a/source/Buoy-Chronology-Tests/NumberChronologyExtensionsTest.class.st
+++ b/source/Buoy-Chronology-Tests/NumberChronologyExtensionsTest.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : #NumberChronologyExtensionsTest,
+	#superclass : #TestCase,
+	#category : #'Buoy-Chronology-Tests'
+}
+
+{ #category : #tests }
+NumberChronologyExtensionsTest >> testDays [
+
+	self
+		assert: 1 day equals: (Duration days: 1);
+		assert: 2 days equals: (Duration days: 2)
+]
+
+{ #category : #tests }
+NumberChronologyExtensionsTest >> testHours [
+
+	self
+		assert: 1 hour equals: (Duration hours: 1);
+		assert: 2 hours equals: (Duration hours: 2)
+]
+
+{ #category : #tests }
+NumberChronologyExtensionsTest >> testSeconds [
+
+	self
+		assert: 1 second equals: (Duration seconds: 1);
+		assert: 2 seconds equals: (Duration seconds: 2)
+]

--- a/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/AbstractDictionary.extension.st
@@ -1,6 +1,18 @@
 Extension { #name : #AbstractDictionary }
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+AbstractDictionary >> associations [
+
+	^ self associationsAsArray
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+AbstractDictionary >> associationsSelect: aBlock [
+
+	^ self selectAssociations: aBlock
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 AbstractDictionary >> at: key ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
 
 	| presentValue |
@@ -29,4 +41,10 @@ AbstractDictionary class >> newFromPairs: anArray [
 	newDictionary := self new: anArray size / 2.
 	1 to: anArray size - 1 by: 2 do: [ :i | newDictionary at: (anArray at: i) put: (anArray at: i + 1) ].
 	^ newDictionary
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+AbstractDictionary >> removeAll [
+
+	^ self removeAllKeys: self keys
 ]

--- a/source/Buoy-Collections-GS64-Extensions/CharacterCollection.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/CharacterCollection.extension.st
@@ -95,13 +95,82 @@ CharacterCollection >> expandMacrosWithArguments: anArray [
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> findTokens: delimiters [
+
+	| separators |
+	separators := delimiters isCharacter
+		              ifTrue: [ delimiters asString ]
+		              ifFalse: [ delimiters ].
+	^ self substrings: separators
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> includesSubstring: substring [
+
+	^ substring isEmpty or: [
+		  (self _findString: substring startingAt: 1 ignoreCase: false) ~~ 0 ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> isAllDigits [
+	"Return whether the receiver is composed entirely of digits and has at least one digit"
+
+	self ifEmpty: [ ^ false ].
+	^ self allSatisfy: #isDigit
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 CharacterCollection class >> lf [
 
 	^ self with: Character lf
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> lines [
+	"Answer an array of lines composing this receiver without the line ending delimiters"
+
+	^ Array
+		  new: (self size // 60 max: 16)
+		  streamContents: [ :lines |
+		  self linesDo: [ :aLine | lines nextPut: aLine ] ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> linesDo: aBlock [
+	"Execute aBlock with each line in this string. The terminating line delimiters CR, LF or CRLF
+	pairs are not included in what is passed to aBlock"
+
+	self lineIndicesDo: [ :start :endWithoutDelimiters :end |
+		aBlock value: (self copyFrom: start to: endWithoutDelimiters) ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> sorted [
+
+	^ self class withAll: super sorted
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 CharacterCollection >> species [
 
 	^ self speciesForConversion
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection class >> tab [
+
+	^ self with: Character tab
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+CharacterCollection >> withoutQuoting [
+	"Remove the initial and final quote marks (single quote for string, or double quotes for comments),
+	if present (and if matches nesting quotes). Have a look at testWithoutQuoting."
+
+	| quote |
+	self size < 2 ifTrue: [ ^ self ].
+	quote := self first.
+	^ (quote = self last and: [ quote = $' or: [ quote = $" ] ])
+		  ifTrue: [ self copyFrom: 2 to: self size - 1 ]
+		  ifFalse: [ self ]
 ]

--- a/source/Buoy-Collections-GS64-Extensions/Collection.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Collection.extension.st
@@ -120,6 +120,24 @@ Collection class >> newFrom: aCollection [
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+Collection >> noneSatisfy: aBlock [
+	"Evaluate aBlock with the elements of the receiver. If aBlock returns false for all elements return true. Otherwise return false"
+
+	self do: [ :item | (aBlock value: item) ifTrue: [ ^ false ] ].
+	^ true
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+Collection >> printElementsOn: aStream [
+	"List elements betwen () and separated by spaces.
+	Is used by printOn: and other related printing methods."
+
+	aStream nextPut: $(.
+	self do: [:element | aStream print: element] separatedBy: [aStream space].
+	aStream nextPut: $)
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 Collection >> removeAll [
 	"Remove each element from the receiver and leave it empty.
 	There are two good reasons why a subclass should override this message:
@@ -133,4 +151,10 @@ Collection >> removeAll [
 Collection >> select: selectBlock thenCollect: collectBlock [
 
 	^ (self select: selectBlock) collect: collectBlock
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+Collection >> sorted [
+
+	^self sortAscending
 ]

--- a/source/Buoy-Collections-GS64-Extensions/Interval.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Interval.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #Interval }
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+Interval >> sorted [
+
+	^ self increment >= 0
+		  ifTrue: [ self copy ]
+		  ifFalse: [ self last to: self first by: self increment negated ]
+]

--- a/source/Buoy-Collections-GS64-Extensions/LookupError.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/LookupError.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #LookupError }
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+LookupError class >> signalFor: key [
+
+	^ self new
+		  key: key;
+		  signal: ('Key <1p> not found.' expandMacrosWith: key)
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+LookupError class >> signalFor: key in: collection [
+
+	^ self new
+		  key: key;
+		  signal: ('Key <1p> not found in <2p>.'
+				   expandMacrosWith: key
+				   with: collection class)
+]

--- a/source/Buoy-Collections-GS64-Extensions/SequenceableCollection.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/SequenceableCollection.extension.st
@@ -40,9 +40,37 @@ SequenceableCollection >> isSequenceable [
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }
+SequenceableCollection >> pairsDo: aBlock [
+	"Evaluate aBlock with my elements taken two at a time.  If there's an odd number of items,
+	ignore the last one.  Allows use of a flattened array for things that naturally group into pairs."
+
+	1 to: self size // 2 do: [ :index |
+		aBlock value: (self at: 2 * index - 1) value: (self at: 2 * index) ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
 SequenceableCollection >> removeAll [
 
 	self ifNotEmpty: [ self removeFrom: 1 to: self size ]
+]
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+SequenceableCollection >> split: aSequenceableCollection indicesDo: aBlock [
+	"Perform an action specified as aBlock (with a start and end argument) to each of the indices of aSequenceableCollection that have been identified by taking the receiver as a splitter."
+
+	| position oldPosition |
+	position := 1.
+	oldPosition := position.
+	position := aSequenceableCollection indexOfSubCollection: self startingAt: position.
+
+	[ position > 0 ] whileTrue: [
+		aBlock value: oldPosition value: position - 1.
+		position := position + self size.
+		oldPosition := position.
+		position := aSequenceableCollection indexOfSubCollection: self startingAt: position.
+	].
+
+	aBlock value: oldPosition value: aSequenceableCollection size
 ]
 
 { #category : #'*Buoy-Collections-GS64-Extensions' }

--- a/source/Buoy-Collections-GS64-Extensions/Set.extension.st
+++ b/source/Buoy-Collections-GS64-Extensions/Set.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Set }
+
+{ #category : #'*Buoy-Collections-GS64-Extensions' }
+Set >> intersection: aCollection [
+
+	^ aCollection select: [ :each | self includes: each ]
+]

--- a/source/Buoy-Collections-Tests/CollectionExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/CollectionExtensionsTest.class.st
@@ -172,6 +172,41 @@ CollectionExtensionsTest >> testMinUsing [
 ]
 
 { #category : #tests }
+CollectionExtensionsTest >> testNoneSatisfy [
+
+	self
+		assert: (#( 2 4 6 ) noneSatisfy: [ :x | x odd ]);
+		deny: (#( 1 2 3 ) noneSatisfy: [ :x | x odd ]);
+		assert: ('hello!' noneSatisfy: #isUppercase);
+		deny: ('hello!' noneSatisfy: #isLetter);
+		assert: (#(  ) noneSatisfy: [ :x | self fail ])
+]
+
+{ #category : #tests }
+CollectionExtensionsTest >> testPairsDo [
+
+	| result |
+	result := OrderedCollection new.
+	
+	#( 1 'fred' 2 'charlie' 3 'elmer' ) pairsDo: [ :number :word |
+		result add: ('<1p>-<2s>' expandMacrosWith: number with: word) ].
+	
+	self
+		assert: result
+		hasTheSameElementsInTheSameOrderThat:
+		#( '1-fred' '2-charlie' '3-elmer' )
+]
+
+{ #category : #tests }
+CollectionExtensionsTest >> testPrintElementsOn [
+
+	self
+		assert:
+		(String streamContents: [ :s | { 10. 'hello' } printElementsOn: s ])
+		equals: '(10 ''hello'')'
+]
+
+{ #category : #tests }
 CollectionExtensionsTest >> testRemoveAll [
 
 	{ Set. OrderedCollection. Bag } do: [ :collectionClass |
@@ -215,6 +250,36 @@ CollectionExtensionsTest >> testSelectThenCollectOnSet [
 		               select: [ :each | each even ]
 		               thenCollect: [ :each | each * 2 ].
 	self assert: evenDoubles equals: (Set withAll: #( 4 24 32 ))
+]
+
+{ #category : #tests }
+CollectionExtensionsTest >> testSetIntersection [
+
+	self
+		assert: (#( 1 2 3 4 ) asSet intersection: #( 3 4 5 ) asSet)
+		equals: #( 3 4 ) asSet;
+		assert: (#( 1 2 3 4 ) asSet intersection: Set new) isEmpty;
+		assert: (Set new intersection: #( 1 2 3 4 ) asSet) isEmpty
+]
+
+{ #category : #tests }
+CollectionExtensionsTest >> testSorted [
+
+	self
+		assert: #( 3 1 4 2 ) sorted equals: #( 1 2 3 4 );
+		assert: 'hello' sorted equals: 'ehllo';
+		assert: (10 to: 1 by: -2) sorted equals: (2 to: 10 by: 2)
+]
+
+{ #category : #tests }
+CollectionExtensionsTest >> testSplitIndicesDo [
+
+	self
+		assert: (String streamContents: [ :s |
+				 '||' split: 'foo||bar||2' indicesDo: [ :start :end |
+					 s << 's:' << start asString << ' ' << 'e:' << end asString
+					 << ' ' ] ])
+		equals: 's:1 e:3 s:6 e:8 s:11 e:11 '
 ]
 
 { #category : #tests }

--- a/source/Buoy-Collections-Tests/DictionaryExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/DictionaryExtensionsTest.class.st
@@ -32,3 +32,15 @@ DictionaryExtensionsTest >> testNewFromPairs [
 		assert: (dictionary at: #one) equals: 1;
 		assert: (dictionary at: #two) equals: 2
 ]
+
+{ #category : #tests }
+DictionaryExtensionsTest >> testRemoveAll [
+
+	| dictionary |
+	dictionary := Dictionary newFromPairs: #( one 1 two 2 ).
+
+	self assert: dictionary size equals: 2.
+
+	dictionary removeAll.
+	self assert: dictionary isEmpty
+]

--- a/source/Buoy-Collections-Tests/StringExtensionsTest.class.st
+++ b/source/Buoy-Collections-Tests/StringExtensionsTest.class.st
@@ -62,9 +62,73 @@ StringExtensionsTest >> testExpandMacrosWithArguments [
 ]
 
 { #category : #tests }
+StringExtensionsTest >> testFindTokens [
+
+	self
+		assert: ('find tokens' findTokens: #( $a $f $n ))
+		hasTheSameElementsInTheSameOrderThat: #( 'i' 'd toke' 's' );
+		
+		assert: ('éèàôüößäóñíá' findTokens: $á)
+		hasTheSameElementsInTheSameOrderThat: #( 'éèàôüößäóñí' );
+		
+		assert: ('' substrings: '')
+		hasTheSameElementsInTheSameOrderThat: #(  );
+		
+		assert: ('test this' substrings: 't')
+		hasTheSameElementsInTheSameOrderThat: #( 'es' ' ' 'his' )
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testIncludesSubstring [
+
+	self
+		assert: ('testing this string' includesSubstring: 'ring');
+		assert: ('éèàôüößäóñíá' includesSubstring: '');
+		assert: ('' includesSubstring: '');
+		deny: ('éèàôüößäóñíá' includesSubstring: 'a');
+		assert: ('éèàôüößäóñíá' includesSubstring: 'ßä');
+		deny: ('kjdsnlksjdf' includesSubstring: 'K')
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testIsAllDigits [
+
+	self
+		assert: '2345' isAllDigits;
+		assert: '0002345' isAllDigits;
+		deny: '2345.88' isAllDigits;
+		deny: '' isAllDigits
+]
+
+{ #category : #tests }
 StringExtensionsTest >> testLf [
 
 	self
 		assert: String lf
 		equals: (String streamContents: [ :stream | stream lf ])
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testLines [
+
+	| string |
+	string := '1<r>2<l>3<r><l>4<n>5' expandMacros.
+
+	self assert: string lines equals: #( '1' '2' '3' '4' '5' )
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testTab [
+
+	self
+		assert: String tab
+		equals: (String streamContents: [ :stream | stream tab ])
+]
+
+{ #category : #tests }
+StringExtensionsTest >> testWithoutQuoting [
+
+	#( '"foo"' 'foo' '''foo''' 'foo' '"foo''' '"foo''' '''foo"' '''foo"'
+	   '"foo' '"foo' 'foo"' 'foo"' 'foo' 'foo' ) pairsDo: [ :before :after |
+		self assert: before withoutQuoting equals: after ]
 ]

--- a/source/Buoy-GS64-Compatibility/ArgumentError.class.st
+++ b/source/Buoy-GS64-Compatibility/ArgumentError.class.st
@@ -8,6 +8,6 @@ packages.
 "
 Class {
 	#name : #ArgumentError,
-	#superclass : #Error,
+	#superclass : #ImproperOperation,
 	#category : #'Buoy-GS64-Compatibility'
 }

--- a/source/Buoy-GS64-Compatibility/Character.extension.st
+++ b/source/Buoy-GS64-Compatibility/Character.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Character }
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Character class >> withValue: anInteger [
+	"Answer the Character whose value is anInteger."
+	<primitive: 170>
+	^self primitiveFailed
+]

--- a/source/Buoy-GS64-Compatibility/Collection.extension.st
+++ b/source/Buoy-GS64-Compatibility/Collection.extension.st
@@ -8,3 +8,9 @@ Collection >> any [
 	self emptyCheck.
 	self do: [ :each | ^ each ]
 ]
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Collection >> sortAscending [
+
+	^self asArray sorted
+]

--- a/source/Buoy-GS64-Compatibility/Date.extension.st
+++ b/source/Buoy-GS64-Compatibility/Date.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #Date }
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Date >> asStringUsingFormat: format [
+
+	^ self printFormat: format
+]
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Date class >> newDay: day month: month year: year [
+
+	^ self starting: (DateAndTime year: year month: month day: day)
+]

--- a/source/Buoy-GS64-Compatibility/DateAndTimeANSI.class.st
+++ b/source/Buoy-GS64-Compatibility/DateAndTimeANSI.class.st
@@ -1,0 +1,15 @@
+"
+In GS64, this protocol describes the behavior that is common to date
+time objects. Date time objects represent individual points
+in Coordinated Universal Time (UTC) as represented in an
+implementation defined local time, with a default resolution
+of seconds.
+
+This version is just a placeholder so we can easily create extensions methods to load in GS64 specific
+packages.
+"
+Class {
+	#name : #DateAndTimeANSI,
+	#superclass : #Magnitude,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-GS64-Compatibility/GsFile.class.st
+++ b/source/Buoy-GS64-Compatibility/GsFile.class.st
@@ -1,0 +1,18 @@
+"
+In GS64, GsFile provides the means for creating and accessing files. These
+files reside in the file system on either the machine that is running the
+current session's Gem process (the server machine) or the machine that is
+running the client application (the client machine).  The files may be of any
+type, textual or binary, though separate protocol is provided for reading and
+writing these types of data.  File contents are in bytes and writing kinds of
+String that require multiple bytes per code pint, the contents must be
+explicitly encoded before write, or written using nextPutAllUtf8:.
+
+This version is just a placeholder so we can easily create extension methods to load in GS64 specific
+packages.
+"
+Class {
+	#name : #GsFile,
+	#superclass : #Object,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-GS64-Compatibility/GsProcess.class.st
+++ b/source/Buoy-GS64-Compatibility/GsProcess.class.st
@@ -1,0 +1,12 @@
+"
+In GS64, a GsProcess represents a suspended or active GemStone Smalltalk green-thread process.
+The in-memory state of a committed GsProcess is not changed by a transaction abort.
+
+This version is just a placeholder so we can easily create extensions methods to load in GS64 specific
+packages.
+"
+Class {
+	#name : #GsProcess,
+	#superclass : #Object,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-GS64-Compatibility/ImproperOperation.class.st
+++ b/source/Buoy-GS64-Compatibility/ImproperOperation.class.st
@@ -1,0 +1,12 @@
+"
+In GS64, ImproperOperation is a superclass for a variety of Smalltalk coding
+errors, such as passing an invalid or out of range argument to a method.
+
+This version is just a placeholder so we can easily create extensions methods to load in GS64 specific
+packages.
+"
+Class {
+	#name : #ImproperOperation,
+	#superclass : #Error,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-GS64-Compatibility/Integer.extension.st
+++ b/source/Buoy-GS64-Compatibility/Integer.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #Integer }
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Integer class >> fromStream: aStream [
+
+	^ (NumberParser on: aStream)
+		  nextIntegerBase: 10
+		  ifFail: [ ImproperOperation signal ]
+]
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Integer class >> fromString: aString [
+
+	^ (NumberParser on: aString)
+		  nextIntegerBase: 10
+		  ifFail: [ ImproperOperation signal ]
+]

--- a/source/Buoy-GS64-Compatibility/Integer.extension.st
+++ b/source/Buoy-GS64-Compatibility/Integer.extension.st
@@ -1,6 +1,23 @@
 Extension { #name : #Integer }
 
 { #category : #'*Buoy-GS64-Compatibility' }
+Integer >> asHexString [ 
+
+	^ self printStringBase: 16
+]
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Integer >> asHexStringWithLength: minimum [
+
+	^ String streamContents: [ :s |
+		  self
+			  printOn: s
+			  base: 16
+			  length: minimum
+			  padded: true ]
+]
+
+{ #category : #'*Buoy-GS64-Compatibility' }
 Integer class >> fromStream: aStream [
 
 	^ (NumberParser on: aStream)

--- a/source/Buoy-GS64-Compatibility/LookupError.class.st
+++ b/source/Buoy-GS64-Compatibility/LookupError.class.st
@@ -1,12 +1,12 @@
 "
-In GS64, OffsetError is an ImproperOperation signaled when an invalid offset
-is used to attempt a lookup.
+In GS64, LookupError is an ImproperOperation that is signaled when a lookup is
+made and not found. The key instance variable holds the missing key.
 
 This version is just a placeholder so we can easily create extensions methods to load in GS64 specific
 packages.
 "
 Class {
-	#name : #OffsetError,
+	#name : #LookupError,
 	#superclass : #ImproperOperation,
 	#category : #'Buoy-GS64-Compatibility'
 }

--- a/source/Buoy-GS64-Compatibility/MultiByteString.class.st
+++ b/source/Buoy-GS64-Compatibility/MultiByteString.class.st
@@ -1,0 +1,9 @@
+"
+MultiByteString is an abstract class in GS64 for representing strings
+for which each Character occupies more than one byte.
+"
+Class {
+	#name : #MultiByteString,
+	#superclass : #Collection,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-GS64-Compatibility/Process.extension.st
+++ b/source/Buoy-GS64-Compatibility/Process.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #Process }
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Process >> environmentAt: object ifAbsent: block [
+
+	| index |
+	index := Process allocatePSKey: object.
+	^ (self psValueAt: index) ifNil: block
+]
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Process >> environmentAt: object put: anotherObject [
+
+	| index |
+	index := Process allocatePSKey: object.
+	^ self psValueAt: index put: anotherObject
+]

--- a/source/Buoy-GS64-Compatibility/Random.extension.st
+++ b/source/Buoy-GS64-Compatibility/Random.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Random }
+
+{ #category : #'*Buoy-GS64-Compatibility' }
+Random >> integerBetween: anInteger and: anInteger2 [
+
+	^ anInteger2 atRandom: SharedRandom globalGenerator
+]

--- a/source/Buoy-GS64-Compatibility/System.class.st
+++ b/source/Buoy-GS64-Compatibility/System.class.st
@@ -1,0 +1,14 @@
+"
+In GS64, System is an abstract class that has no instances.  It implements class
+methods for object locking and for operations that are usually found in
+traditional operating systems.  The data curator may restrict user access to
+these messages.
+
+This version is just a placeholder so we can easily create extensions methods to load in GS64 specific
+packages.
+"
+Class {
+	#name : #System,
+	#superclass : #Object,
+	#category : #'Buoy-GS64-Compatibility'
+}

--- a/source/Buoy-Math-GS64-Base-Extensions/Integer.extension.st
+++ b/source/Buoy-Math-GS64-Base-Extensions/Integer.extension.st
@@ -26,3 +26,39 @@ Integer >> isInteger [
 
 	^ true
 ]
+
+{ #category : #'*Buoy-Math-GS64-Base-Extensions' }
+Integer >> printStringHex [
+
+	^ self asHexString asUppercase
+]
+
+{ #category : #'*Buoy-Math-GS64-Base-Extensions' }
+Integer >> printStringLength: minimum padded: zeroFlag [
+
+	| numberPrintString preffix |
+	numberPrintString := self abs printString.
+	preffix := self negative then: [ '-' ] otherwise: [ '' ].
+	^ String streamContents: [ :stream |
+		  | padLength |
+		  padLength := minimum - numberPrintString size - preffix size.
+		  stream nextPutAll: preffix.
+		  padLength strictlyPositive then: [
+			  | filler |
+			  filler := zeroFlag
+				            ifTrue: [ $0 ]
+				            ifFalse: [ Character space ].
+			  padLength timesRepeat: [ stream nextPut: filler ] ].
+		  stream nextPutAll: numberPrintString ]
+]
+
+{ #category : #'*Buoy-Math-GS64-Base-Extensions' }
+Integer class >> readFrom: aStringOrStream ifFail: aBlock [
+
+	^ [
+	  aStringOrStream isString
+		  ifTrue: [ self fromString: aStringOrStream ]
+		  ifFalse: [ self fromStream: aStringOrStream ] ]
+		  on: ImproperOperation
+		  do: [ :error | error return: aBlock value ]
+]

--- a/source/Buoy-Math-Tests/BuoyNumberExtensionsTest.class.st
+++ b/source/Buoy-Math-Tests/BuoyNumberExtensionsTest.class.st
@@ -65,9 +65,42 @@ BuoyNumberExtensionsTest >> testIncreasedBy [
 ]
 
 { #category : #tests }
+BuoyNumberExtensionsTest >> testIntegerReadFromIfFail [
+
+	self
+		assert: (Integer readFrom: '12' ifFail: [ self fail ]) equals: 12;
+		assert: (Integer readFrom: '-12' ifFail: [ self fail ]) equals: -12;
+		assert: (Integer readFrom: 'AA' ifFail: [ 95 ]) equals: 95;
+		assert: (Integer readFrom: '23AA' ifFail: [ self fail ]) equals: 23;
+		assert: (Integer readFrom: 'AA33' ifFail: [ 95 ]) equals: 95;
+		assert: (Integer readFrom: '12' readStream ifFail: [ self fail ])
+		equals: 12
+]
+
+{ #category : #tests }
 BuoyNumberExtensionsTest >> testIsPercentage [
 
 	self
 		assert: 10 percent isPercentage;
 		deny: 10 isPercentage
+]
+
+{ #category : #tests }
+BuoyNumberExtensionsTest >> testPrintStringHex [
+
+	self
+		assert: 1 printStringHex equals: '1';
+		assert: 10 printStringHex equals: 'A';
+		assert: 17 printStringHex equals: '11'
+]
+
+{ #category : #tests }
+BuoyNumberExtensionsTest >> testPrintStringLenghtPadded [
+
+	self
+		assert: (10 printStringLength: 4 padded: true) equals: '0010';
+		assert: (-10 printStringLength: 4 padded: true) equals: '-010';
+		assert: (10000 printStringLength: 4 padded: true) equals: '10000';
+		assert: (1000 printStringLength: 4 padded: true) equals: '1000';
+		assert: (10 printStringLength: 4 padded: false) equals: '  10'
 ]

--- a/source/Buoy-Metaprogramming-Extensions/LanguagePlatform.class.st
+++ b/source/Buoy-Metaprogramming-Extensions/LanguagePlatform.class.st
@@ -22,6 +22,12 @@ LanguagePlatform class >> setCurrentTo: aLanguagePlatform [
 	^ Current
 ]
 
+{ #category : #'process scheduling' }
+LanguagePlatform >> fork: block named: processName at: priority [
+
+	self subclassResponsibility
+]
+
 { #category : #reflection }
 LanguagePlatform >> globalNamed: aSymbol ifAbsent: absentBlock [
 
@@ -29,7 +35,22 @@ LanguagePlatform >> globalNamed: aSymbol ifAbsent: absentBlock [
 ]
 
 { #category : #reflection }
+LanguagePlatform >> globalNamed: aSymbol ifPresent: presentBlock ifAbsent: absentBlock [
+
+	| global |
+	global := self globalNamed: aSymbol ifAbsent: [ ^ absentBlock value ].
+	^ presentBlock cull: global
+]
+
+{ #category : #reflection }
 LanguagePlatform >> includesGlobalNamed: aSymbol [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+LanguagePlatform >> os [
+	"Returns the underlying operating system abstraction"
 
 	^ self subclassResponsibility
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/Class.extension.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/Class.extension.st
@@ -11,6 +11,13 @@ Class >> allLeafSubclasses [
 ]
 
 { #category : #'*Buoy-Metaprogramming-GS64-Extensions' }
+Class >> allSubclassesDo: aBlock [
+	"Evaluate the argument, aBlock, for each of the receiver's subclasses."
+
+	self allSubclasses do: aBlock
+]
+
+{ #category : #'*Buoy-Metaprogramming-GS64-Extensions' }
 Class >> subclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for each of the receiver's immediate subclasses."
 

--- a/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
@@ -16,8 +16,8 @@ DynamicVariable class >> value [
 	"Answer the current value for this variable in the current context."
 
 	^ Processor activeProcess
-		  environmentAt: self
-		  ifAbsent: [ self default ]
+		  environmentAt: self soleInstance
+		  ifAbsent: [ self soleInstance default ]
 ]
 
 { #category : #evaluating }
@@ -26,10 +26,16 @@ DynamicVariable class >> value: anObject during: aBlock [
 	| activeProcess oldValue |
 	activeProcess := Processor activeProcess.
 	oldValue := activeProcess
-		            environmentAt: self
-		            ifAbsent: [ self default ].
+		            environmentAt: self soleInstance
+		            ifAbsent: [ self soleInstance default ].
 	^ [
 	  activeProcess environmentAt: self put: anObject.
 	  aBlock value ] ensure: [
-		  activeProcess environmentAt: self put: oldValue ]
+		  activeProcess environmentAt: self soleInstance put: oldValue ]
+]
+
+{ #category : #accessing }
+DynamicVariable class >> soleInstance [
+
+	^ self
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/DynamicVariable.class.st
@@ -11,6 +11,18 @@ DynamicVariable class >> default [
 	^ nil
 ]
 
+{ #category : #testing }
+DynamicVariable class >> isInheritable [
+
+	^ false
+]
+
+{ #category : #accessing }
+DynamicVariable class >> soleInstance [
+
+	^ self
+]
+
 { #category : #evaluating }
 DynamicVariable class >> value [
 	"Answer the current value for this variable in the current context."
@@ -32,10 +44,4 @@ DynamicVariable class >> value: anObject during: aBlock [
 	  activeProcess environmentAt: self put: anObject.
 	  aBlock value ] ensure: [
 		  activeProcess environmentAt: self soleInstance put: oldValue ]
-]
-
-{ #category : #accessing }
-DynamicVariable class >> soleInstance [
-
-	^ self
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64Platform.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64Platform.class.st
@@ -10,6 +10,20 @@ GemStone64Platform class >> initialize [
 	LanguagePlatform setCurrentTo: self new
 ]
 
+{ #category : #'process scheduling' }
+GemStone64Platform >> fork: block named: processName at: priority [
+
+	| process |
+	process := block newProcess.
+	process
+		beForked;
+		name: processName;
+		priority: priority.
+	process resume.
+	Processor yield.
+	^process
+]
+
 { #category : #reflection }
 GemStone64Platform >> globalNamed: aSymbol ifAbsent: absentBlock [
 
@@ -22,4 +36,10 @@ GemStone64Platform >> includesGlobalNamed: aSymbol [
 
 	^ (GsCurrentSession currentSession symbolList objectNamed: aSymbol)
 		  notNil
+]
+
+{ #category : #accessing }
+GemStone64Platform >> os [
+
+	^ GemStone64UnixPlatform current
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64UnixPlatform.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64UnixPlatform.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #GemStone64UnixPlatform,
+	#superclass : #Object,
+	#classInstVars : [
+		'Current'
+	],
+	#category : #'Buoy-Metaprogramming-GS64-Extensions'
+}
+
+{ #category : #accessing }
+GemStone64UnixPlatform class >> current [
+
+	^ Current
+]
+
+{ #category : #'class initialization' }
+GemStone64UnixPlatform class >> initialize [
+
+	Current := self new
+]
+
+{ #category : #accessing }
+GemStone64UnixPlatform >> lineEnding [
+
+	^ String lf
+]

--- a/source/Buoy-Metaprogramming-Pharo-Extensions/PharoPlatform.class.st
+++ b/source/Buoy-Metaprogramming-Pharo-Extensions/PharoPlatform.class.st
@@ -11,6 +11,12 @@ PharoPlatform class >> initialize [
 	LanguagePlatform setCurrentTo: self new
 ]
 
+{ #category : #'process scheduling' }
+PharoPlatform >> fork: block named: processName at: priority [
+
+	^ block forkAt: priority named: processName
+]
+
 { #category : #reflection }
 PharoPlatform >> globalNamed: aSymbol ifAbsent: absentBlock [
 
@@ -21,4 +27,10 @@ PharoPlatform >> globalNamed: aSymbol ifAbsent: absentBlock [
 PharoPlatform >> includesGlobalNamed: aSymbol [
 
 	^ Smalltalk globals includesKey: aSymbol
+]
+
+{ #category : #accessing }
+PharoPlatform >> os [
+
+	^ OSPlatform current
 ]

--- a/source/Buoy-Metaprogramming-Tests/BuoyMetaprogrammingExtensionsTest.class.st
+++ b/source/Buoy-Metaprogramming-Tests/BuoyMetaprogrammingExtensionsTest.class.st
@@ -18,6 +18,22 @@ BuoyMetaprogrammingExtensionsTest >> testBehaviorAllLeafSubclasses [
 		assert: MessageSendingCollector allLeafSubclasses includes: UnaryMessageSendingCollector
 ]
 
+{ #category : #tests }
+BuoyMetaprogrammingExtensionsTest >> testBehaviorAllSubclassesDo [
+
+	| collectorSubclasses |
+	self class allSubclassesDo: [ :class | self fail ].
+
+	collectorSubclasses := OrderedCollection new.
+	MessageSendingCollector allSubclassesDo: [ :class |
+		collectorSubclasses add: class ].
+	self
+		assert: collectorSubclasses size equals: 2;
+		assert: collectorSubclasses
+		includes: KeywordMessageSendingCollector;
+		assert: collectorSubclasses includes: UnaryMessageSendingCollector
+]
+
 { #category : #test }
 BuoyMetaprogrammingExtensionsTest >> testIsA [
 

--- a/source/Buoy-Metaprogramming-Tests/LanguagePlatformTest.class.st
+++ b/source/Buoy-Metaprogramming-Tests/LanguagePlatformTest.class.st
@@ -5,6 +5,24 @@ Class {
 }
 
 { #category : #tests }
+LanguagePlatformTest >> testForkNamedAt [
+
+	| wasEvaluated semaphore |
+	wasEvaluated := false.
+	semaphore := Semaphore new.
+
+	LanguagePlatform current
+		fork: [
+			wasEvaluated := true.
+			semaphore signal ]
+		named: 'Testing LanguagePlatform fork'
+		at: Processor userBackgroundPriority.
+	semaphore wait.
+
+	self assert: wasEvaluated
+]
+
+{ #category : #tests }
 LanguagePlatformTest >> testGlobalNamedIfAbsent [
 
 	| sentinel |

--- a/source/Buoy-Metaprogramming-Tests/LanguagePlatformTest.class.st
+++ b/source/Buoy-Metaprogramming-Tests/LanguagePlatformTest.class.st
@@ -23,6 +23,28 @@ LanguagePlatformTest >> testGlobalNamedIfAbsent [
 ]
 
 { #category : #tests }
+LanguagePlatformTest >> testGlobalNamedIfPresentIfAbsent [
+
+	| sentinel |
+	self
+		assert: (LanguagePlatform current
+				 globalNamed: self class name
+				 ifPresent: [ :global |
+					 self assert: global equals: self class.
+					 global ]
+				 ifAbsent: [ self fail ])
+		equals: self class.
+
+	sentinel := Object new.
+	self
+		assert: (LanguagePlatform current
+				 globalNamed: #AnImplausibleGlobalName
+				 ifPresent: [ self fail ]
+				 ifAbsent: [ sentinel ])
+		identicalTo: sentinel
+]
+
+{ #category : #tests }
 LanguagePlatformTest >> testIncludesGlobalNamed [
 
 	self
@@ -30,4 +52,12 @@ LanguagePlatformTest >> testIncludesGlobalNamed [
 			(LanguagePlatform current includesGlobalNamed: self class name);
 		deny: (LanguagePlatform current includesGlobalNamed:
 					 #AnImplausibleGlobalName)
+]
+
+{ #category : #tests }
+LanguagePlatformTest >> testOSLineEnding [
+
+	self
+		assert: LanguagePlatform current os lineEnding
+		equals: '<n>' expandMacros
 ]

--- a/source/Buoy-SUnit-GS64-Extensions/TestAsserter.extension.st
+++ b/source/Buoy-SUnit-GS64-Extensions/TestAsserter.extension.st
@@ -34,14 +34,6 @@ TestAsserter >> assertCollection: actual hasSameElements: expected [
 ]
 
 { #category : #'*Buoy-SUnit-GS64-Extensions' }
-TestAsserter >> assertString: aString equals: anotherString [
-
-	self
-		assert: aString asUnicodeString
-		equals: anotherString asUnicodeString
-]
-
-{ #category : #'*Buoy-SUnit-GS64-Extensions' }
 TestAsserter >> deny: actual identicalTo: expected [
 
 	self deny: expected == actual

--- a/source/Buoy-SUnit-Pharo-Extensions/TestAsserter.extension.st
+++ b/source/Buoy-SUnit-Pharo-Extensions/TestAsserter.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #TestAsserter }
-
-{ #category : #'*Buoy-SUnit-Pharo-Extensions' }
-TestAsserter >> assertString: aString equals: anotherString [
-
-	self assert: aString equals: anotherString
-]


### PR DESCRIPTION
- Update Baseline to load `Development` group as default
- GS/64 extensions
	- Chronology
		- Add `Date>>#asDateAndTime`
		- Add `DateAndTime >>#asDateAndTime`
		- Add `DateAndTImeANSI` `#monthIndex` `#printHMSOn:` `#printYMDOn:` `year:month:date`
		- Add `Integer` `#day`, `#days`, `#hour` and `#hours`
		- Add `Number` `#second` and `#seconds`
		- Add `Time class` `#milliseconds:since`, `#millisecondsSince:` and `#totalSeconds`
	- Collections
		- Add `AbstractDictionary` `#associations` and `#removeAll`
		- Add `CharacterCollection` `#findTokens:`, `#includesSubstring:` , `#isAllDigits`, `#lines`, `#linesDo:`, `#sorted`, `#tab` and `#withoutQuoting`
		- Add `Collection` `#noneSatisfy:` , `#printElementsOn:` and `#sorted`
		- Add `Interval>>#sorted`
		- Make `LookupError` polymorphic with `NotFound`
		- Add `SequenceableCollection` `#pairsDo:` and `#split:indicesDo:`
		- Add `Set>>#intersection:`
	- Math
		- Add `Integer` `#printStringHex`, `#printStringLenght:padded:` and `readFrom:ifFail:`
	- Metaprogramming
		- Add `LanguagePlatform` `#fork:named:at:`, `#globalNamed:ifPresent:ifAbsent:` and `os`
		- Add `Class>>#allSubclassesDo:`