### PR TITLE
Improve GS64 component definitions

### DIFF
--- a/docs/how-to/how-to-load-in-pharo.md
+++ b/docs/how-to/how-to-load-in-pharo.md
@@ -27,7 +27,7 @@
 6. Click *Ok*
 7. Select the repository in the main Iceberg window
 8. Open the contextual menu and select
-  *Metacello -> Install baseline of Buoy ...*
+  *Metacello → Install baseline of Buoy ...*
 9. Type `Development` and click *Ok*
 
 > After Iceberg cloned a repository, it will be checked-out at the default

--- a/docs/reference/BindingsAndOptionals.md
+++ b/docs/reference/BindingsAndOptionals.md
@@ -21,7 +21,7 @@ either be present or not. In some ways it's similar to the Maybe monad, but it
 does not pretend to be a monad.
 
 So let's say we have a user interface where we want to show the details of some
-file the user has to upload. At the beginning there is no file so we can start
+file the user has to upload. At the beginning there is no file, so we can start
 with an unused optional:
 
 ```smalltalk
@@ -60,7 +60,7 @@ We can transform an optional:
 fileOptional return: [:file | file asUrl ]
 ```
 
-This will produce a new optional that will have an URL based on the file, or an
+This will produce a new optional that will have a URL based on the file, or an
 unused one in case the file is missing.
 
 We can easily combine two optionals:
@@ -75,9 +75,9 @@ fileOptional
 This will produce a new optional that will have the concatenation as its content,
 or an unused one in case some part is missing.
 
-If we have a list of optionals it's possible to combine them to get a new
-optional as a result. So suppose we have a list of possible numbers and we want
-to get the sum only if all are available. We can do that by sending the
+If we have a list of optionals, it's possible to combine them to get a new
+optional as a result. So suppose we have a list of possible numbers, and we
+want to get the sum only if all are available. We can do that by sending the
 following message:
 
 ```smalltalk

--- a/docs/reference/Collections.md
+++ b/docs/reference/Collections.md
@@ -98,7 +98,7 @@ Some examples
 - `associations` returns the collection of associations.
 - `at:ifPresent:ifAbsentPut:` lookups a value, if any matches evaluates a block,
   if no one matches put under the key the result o evaluating the second block.
-- `removeAll` removes all elments on the dictionary.
+- `removeAll` removes all elements on the dictionary.
 
 ## `String` extensions for GS64
 

--- a/docs/reference/Comparison.md
+++ b/docs/reference/Comparison.md
@@ -38,11 +38,11 @@ Equality checkers help to implement the equality method for objects. Any object
 can send to itself the message `equalityChecker`, configure it and then use it
 to check against the target object of the comparison.
 
-Equality checkers always performs a `==` comparison first and proceed with the
+Equality checkers always perform a `==` comparison first and proceed with the
 rest of the rules only if the objects are not identical.
 
-By default `equalityChecker` is an instance of `PropertyBasedEqualityChecker`
-and it already knowns the receiving instance. It can be configured with:
+By default, `equalityChecker` is an instance of `PropertyBasedEqualityChecker`
+and it already knows the receiving instance. It can be configured with:
 
 - `compare: selector` will add a rule to the checker that sends the provided
   message on the receiver and target object and compare the results by `=`
@@ -64,7 +64,7 @@ sequenceable and contains the same elements in the same order.
 
 ### Equality Checker Examples
 
-This examples assumes that equalityChecker is not reimplemented.
+These examples assume that `equalityChecker` is not reimplemented.
 
 ```smalltalk
 "Just type checking"

--- a/docs/reference/Conditions.md
+++ b/docs/reference/Conditions.md
@@ -54,7 +54,7 @@ condition isSatisfiedBy: 0. "returns true"
 
 ### Composite Condition
 
-You can compose conditions using AND or OR as a logic operator. A simple AND
+You can compose conditions using `AND` or `OR` as a logic operator. A simple AND
 composition could be used to test if a number is within an interval.
 
 ```smalltalk
@@ -79,7 +79,7 @@ condition isSatisfiedBy: 0. "returns false"
 
 ### Regex Condition
 
-RegexCondition could be used to test a string against a regular expression.
+`RegexCondition` could be used to test a string against a regular expression.
 
 ```smalltalk
 | condition |

--- a/docs/reference/Namespaces.md
+++ b/docs/reference/Namespaces.md
@@ -13,7 +13,7 @@ cssConstants
   bind: #white to: Color white
 ```
 
-By default you can't bind a name already bound, but you can use the `rebind:to:`
+By default, you can't bind a name already bound, but you can use the `rebind:to:`
 message to accomplish that.
 
 Now it's possible to access the object bound by name:

--- a/docs/tutorial/Assertions.md
+++ b/docs/tutorial/Assertions.md
@@ -1,6 +1,6 @@
 # Assertions Tutorial
 
-For this tutorial we will use a simple model: ISO 3166-1 Alpha-2 codes. This
+For this tutorial we will use a simple model: ISO 3166-1 Alpha-2 codes. These
 codes are two-letter country codes defined in the corresponding [ISO standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
 ## Single Conditions
@@ -29,7 +29,7 @@ exception is raised including the provided explanation.
 
 ## Multiple Conditions
 
-Now in the previous example we missed some of the requirements of the standard:
+Now in the previous example we missed some requirements of the standard:
 a valid code consists only of letters. So let's rewrite our example:
 
 ```smalltalk
@@ -48,8 +48,8 @@ AssertionChecker
 ```
 
 Note that in this case we are configuring all the conditions to enforce. Let's
-try now replacing `code` with `'AR3'` and `Do it` again. By default all the
-conditions to enforce are checked so you should get an error message combining
+try now replacing `code` with `'AR3'` and `Do it` again. By default, all the
+conditions to enforce are checked, so you should get an error message combining
 both explanations, and if you handle the raised exception you can get all the
 failures by sending it the message `failures`.
 

--- a/rowan/components/Dependent-SUnit-Extensions.ston
+++ b/rowan/components/Dependent-SUnit-Extensions.ston
@@ -11,12 +11,8 @@ RwSimpleProjectLoadComponentV2 {
     'gemstone' : {
       'allusers' : {
         #packageNameToPlatformPropertiesMap : {
-          'Buoy-SUnit-Model' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-SUnit-GS64-Extensions' : {
-            'symbolDictName' : 'Globals'
-          }
+          'Buoy-SUnit-Model' : { 'symbolDictName' : 'Globals' },
+          'Buoy-SUnit-GS64-Extensions' : { 'symbolDictName' : 'Globals' }
         }
       }
     }

--- a/rowan/components/Deployment.ston
+++ b/rowan/components/Deployment.ston
@@ -29,39 +29,25 @@ RwSimpleProjectLoadComponentV2 {
     'gemstone' : {
       'allusers' : {
         #packageNameToPlatformPropertiesMap : {
-          'Buoy-Assertions-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Chronology-GS64-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Collections-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Collections-GS64-Extensions' : {
-            'symbolDictName' : 'Globals'
-           },
-          'Buoy-Comparison-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Conditions-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Exception-Handling-Extensions' : {
-            'symbolDictName' : 'Globals'
-           },
-          'Buoy-Math-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Math-GS64-Base-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Metaprogramming-Extensions' : {
-            'symbolDictName' : 'Globals'
-          },
-          'Buoy-Metaprogramming-GS64-Extensions' : {
-            'symbolDictName' : 'Globals'
-          }
+          'Buoy-Assertions' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Assertions-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Chronology-GS64-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Collections' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Collections-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Collections-GS64-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Comparison' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Comparison-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Conditions' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Conditions-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Dynamic-Binding' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Exception-Handling-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Math' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Math-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Math-GS64-Base-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Math-GS64-Extensions' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Metaprogramming' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Metaprogramming-Extensions' : { 'symbolDictName' : 'Globals' },
+          'Buoy-Metaprogramming-GS64-Extensions' : { 'symbolDictName' : 'Globals' }
         }
       }
     }

--- a/rowan/components/Tests.ston
+++ b/rowan/components/Tests.ston
@@ -18,5 +18,23 @@ RwSimpleProjectLoadComponentV2 {
     'Buoy-Metaprogramming-Tests',
     'Buoy-SUnit-Tests'
   ],
+  #conditionalPackageMapSpecs : {
+    'gemstone' : {
+      'allusers' : {
+        #packageNameToPlatformPropertiesMap : {
+          'Buoy-Assertions-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Chronology-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Collections-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Comparison-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Conditions-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Dynamic-Binding-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Exception-Handling-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Math-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-Metaprogramming-Tests' : { 'symbolDictName' : 'Buoy' },
+          'Buoy-SUnit-Tests' : { 'symbolDictName' : 'Buoy' }
+        }
+      }
+    }
+  },
   #comment : ''
 }

--- a/rowan/specs/Buoy-CI.ston
+++ b/rowan/specs/Buoy-CI.ston
@@ -6,13 +6,6 @@ RwLoadSpecificationV2 {
   #componentNames : [
     'Tests'
   ],
-  #platformProperties : {
-    'gemstone' : {
-      'allusers' : {
-        #defaultSymbolDictName : 'Buoy'
-      }
-    }
-  },
   #customConditionalAttributes : [
     'tests',
     'sunit'

--- a/rowan/specs/Buoy-Dependent-SUnit-Extensions.ston
+++ b/rowan/specs/Buoy-Dependent-SUnit-Extensions.ston
@@ -6,13 +6,6 @@ RwLoadSpecificationV2 {
   #componentNames : [
     'Dependent-SUnit-Extensions'
   ],
-  #platformProperties : {
-    'gemstone' : {
-      'allusers' : {
-        #defaultSymbolDictName : 'Buoy'
-      }
-    }
-  },
   #customConditionalAttributes : [
     'sunit'
   ],

--- a/rowan/specs/Buoy-Deployment.ston
+++ b/rowan/specs/Buoy-Deployment.ston
@@ -6,12 +6,5 @@ RwLoadSpecificationV2 {
   #componentNames : [
     'Deployment'
   ],
-  #platformProperties : {
-    'gemstone' : {
-      'allusers' : {
-        #defaultSymbolDictName : 'Buoy'
-      }
-    }
-  },
   #comment : 'Loading spec for Deployment'
 }

--- a/source/Buoy-Metaprogramming-Extensions/LanguagePlatform.class.st
+++ b/source/Buoy-Metaprogramming-Extensions/LanguagePlatform.class.st
@@ -10,8 +10,8 @@ Class {
 { #category : #accessing }
 LanguagePlatform class >> current [
 
-	Current ifNil: [ Error signal: 'The language platform was not set' ].
-	^Current
+	Current ifNil: [ self setCurrentTo: self allLeafSubclasses any new ].
+	^ Current
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
GS64 component definitions now explicit the symbol dictionary for each package, mostly to avoid having to repeat the default symbol list declaration in every load spec.

Fixed some typos in the docs