### PR TITLE
Add methods for global management in LanguagePlatform

### DIFF
--- a/source/Buoy-Development-Tools-Pharo-12/CircularIterator.extension.st
+++ b/source/Buoy-Development-Tools-Pharo-12/CircularIterator.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'CircularIterator' }
+
+{ #category : '*Buoy-Development-Tools-Pharo-12' }
+CircularIterator class >> systemIconName [
+
+  ^ #collection
+]

--- a/source/Buoy-Development-Tools-Pharo-12/Formatter.extension.st
+++ b/source/Buoy-Development-Tools-Pharo-12/Formatter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'Formatter' }
+
+{ #category : '*Buoy-Development-Tools-Pharo-12' }
+Formatter class >> systemIconName [
+
+  ^ #string
+]

--- a/source/Buoy-Development-Tools-Pharo-12/SearchMethodsForLocalizationMessagesRule.class.st
+++ b/source/Buoy-Development-Tools-Pharo-12/SearchMethodsForLocalizationMessagesRule.class.st
@@ -18,6 +18,7 @@ SearchMethodsForLocalizationMessagesRule class >> collectingTranslationsIn: aCol
 SearchMethodsForLocalizationMessagesRule >> initialize [
 
   super initialize.
+  stringsToTranslate := OrderedCollection new.
   matcher
     matches: '`#string localized'
     do: [ :node :answer | stringsToTranslate add: node receiver value ];

--- a/source/Buoy-Development-Tools-Pharo-12/SearchMethodsForLocalizationMessagesRule.class.st
+++ b/source/Buoy-Development-Tools-Pharo-12/SearchMethodsForLocalizationMessagesRule.class.st
@@ -14,6 +14,12 @@ SearchMethodsForLocalizationMessagesRule class >> collectingTranslationsIn: aCol
   ^ self new initializeCollectingTranslationsIn: aCollection
 ]
 
+{ #category : 'testing' }
+SearchMethodsForLocalizationMessagesRule class >> isVisible [
+
+  ^ false
+]
+
 { #category : 'initialization' }
 SearchMethodsForLocalizationMessagesRule >> initialize [
 

--- a/source/Buoy-Metaprogramming-Extensions/LanguagePlatform.class.st
+++ b/source/Buoy-Metaprogramming-Extensions/LanguagePlatform.class.st
@@ -42,6 +42,12 @@ LanguagePlatform >> globalNamed: aSymbol ifAbsent: absentBlock [
 ]
 
 { #category : 'reflection' }
+LanguagePlatform >> globalNamed: symbol ifAbsentPut: block [
+
+  ^ self subclassResponsibility
+]
+
+{ #category : 'reflection' }
 LanguagePlatform >> globalNamed: aSymbol ifPresent: presentBlock ifAbsent: absentBlock [
 
 	| global |
@@ -72,6 +78,12 @@ LanguagePlatform >> newProcessNamed: processName evaluating: block at: priority 
 { #category : 'accessing' }
 LanguagePlatform >> os [
 	"Returns the underlying operating system abstraction"
+
+	^ self subclassResponsibility
+]
+
+{ #category : 'reflection' }
+LanguagePlatform >> removeGlobalNamed: aSymbol ifAbsent: absentBlock [
 
 	^ self subclassResponsibility
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64Platform.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64Platform.class.st
@@ -1,35 +1,35 @@
 Class {
-	#name : 'GemStone64Platform',
-	#superclass : 'LanguagePlatform',
-	#category : 'Buoy-Metaprogramming-GS64-Extensions',
-	#package : 'Buoy-Metaprogramming-GS64-Extensions'
+  #name : 'GemStone64Platform',
+  #superclass : 'LanguagePlatform',
+  #category : 'Buoy-Metaprogramming-GS64-Extensions',
+  #package : 'Buoy-Metaprogramming-GS64-Extensions'
 }
 
 { #category : 'class initialization' }
 GemStone64Platform class >> initialize [
 
-	LanguagePlatform setCurrentTo: self new
+  LanguagePlatform setCurrentTo: self new
 ]
 
 { #category : 'reflection' }
 GemStone64Platform >> atInstanceVariableNamed: name on: object put: value [
 
-	| index |
-	index := (object class allInstVarNames collect: #asSymbol)
-		indexOf: name asSymbol
-		ifAbsent: [ self error: ('<1s> not found in <2p>' expandMacrosWith: name asString with: object) ].
-	object instVarAt: index put: value
+  | index |
+  index := (object class allInstVarNames collect: #asSymbol)
+    indexOf: name asSymbol
+    ifAbsent: [ self error: ('<1s> not found in <2p>' expandMacrosWith: name asString with: object) ].
+  object instVarAt: index put: value
 
 ]
 
 { #category : 'process scheduling' }
 GemStone64Platform >> fork: block named: processName at: priority [
 
-	| process |
-	process := self newProcessNamed: processName evaluating: block at: priority.
-	process resume.
-	Processor yield.
-	^process
+  | process |
+  process := self newProcessNamed: processName evaluating: block at: priority.
+  process resume.
+  Processor yield.
+  ^process
 ]
 
 { #category : 'process scheduling' }
@@ -45,15 +45,28 @@ GemStone64Platform >> newProcessNamed: processName evaluating: block at: priorit
 { #category : 'reflection' }
 GemStone64Platform >> globalNamed: aSymbol ifAbsent: absentBlock [
 
-	^ (GsCurrentSession currentSession symbolList objectNamed: aSymbol)
-		  ifNil: absentBlock
+  ^ (GsCurrentSession currentSession objectNamed: aSymbol)
+      ifNil: absentBlock
+]
+
+{ #category : 'reflection' }
+GemStone64Platform >> globalNamed: symbol ifAbsentPut: block [
+
+  ^ (GsCurrentSession currentSession objectNamed: aSymbol)
+      ifNil: [
+        | object |
+        object := block value.
+        (GsCurrentSession currentSession objectNamed: #Globals)
+          at: aSymbol put: object.
+        object
+      ]
 ]
 
 { #category : 'reflection' }
 GemStone64Platform >> includesGlobalNamed: aSymbol [
 
-	^ (GsCurrentSession currentSession symbolList objectNamed: aSymbol)
-		  notNil
+  ^ (GsCurrentSession currentSession objectNamed: aSymbol)
+      notNil
 ]
 
 { #category : 'message digest' }
@@ -65,5 +78,13 @@ GemStone64Platform >> messageDigest: string [
 { #category : 'accessing' }
 GemStone64Platform >> os [
 
-	^ GemStone64UnixPlatform current
+  ^ GemStone64UnixPlatform current
+]
+
+{ #category : 'reflection' }
+GemStone64Platform >> removeGlobalNamed: aSymbol ifAbsent: absentBlock [
+
+  | globals |
+  globals := GsCurrentSession currentSession objectNamed: #Globals.
+  ^ globals removeKey: aSymbol ifAbsent: absentBlock
 ]

--- a/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64Platform.class.st
+++ b/source/Buoy-Metaprogramming-GS64-Extensions/GemStone64Platform.class.st
@@ -52,12 +52,12 @@ GemStone64Platform >> globalNamed: aSymbol ifAbsent: absentBlock [
 { #category : 'reflection' }
 GemStone64Platform >> globalNamed: symbol ifAbsentPut: block [
 
-  ^ (GsCurrentSession currentSession objectNamed: aSymbol)
+  ^ (GsCurrentSession currentSession objectNamed: symbol)
       ifNil: [
         | object |
         object := block value.
         (GsCurrentSession currentSession objectNamed: #Globals)
-          at: aSymbol put: object.
+          at: symbol put: object.
         object
       ]
 ]

--- a/source/Buoy-Metaprogramming-Pharo-Extensions/PharoPlatform.class.st
+++ b/source/Buoy-Metaprogramming-Pharo-Extensions/PharoPlatform.class.st
@@ -31,6 +31,12 @@ PharoPlatform >> globalNamed: aSymbol ifAbsent: absentBlock [
 ]
 
 { #category : 'reflection' }
+PharoPlatform >> globalNamed: symbol ifAbsentPut: block [
+
+  ^ Smalltalk globals at: symbol ifAbsentPut: block
+]
+
+{ #category : 'reflection' }
 PharoPlatform >> includesGlobalNamed: aSymbol [
 
 	^ Smalltalk globals includesKey: aSymbol
@@ -55,4 +61,10 @@ PharoPlatform >> newProcessNamed: processName evaluating: block at: priority [
 PharoPlatform >> os [
 
 	^ OSPlatform current
+]
+
+{ #category : 'reflection' }
+PharoPlatform >> removeGlobalNamed: aSymbol ifAbsent: absentBlock [
+
+  ^ Smalltalk globals removeKey: aSymbol ifAbsent: absentBlock
 ]

--- a/source/Buoy-Metaprogramming-Tests/LanguagePlatformTest.class.st
+++ b/source/Buoy-Metaprogramming-Tests/LanguagePlatformTest.class.st
@@ -55,6 +55,27 @@ LanguagePlatformTest >> testGlobalNamedIfAbsent [
 ]
 
 { #category : 'tests' }
+LanguagePlatformTest >> testGlobalNamedIfAbsentPut [
+
+  | globalName globalValue sentinel |
+  globalName := #TestGlobalNamedIfAbsentPut.
+  globalValue := Object new.
+
+  LanguagePlatform current globalNamed: globalName ifAbsentPut: globalValue.
+
+  self
+    assert: ( LanguagePlatform current globalNamed: globalName ifAbsent: [ self fail ] )
+    identicalTo: globalValue.
+
+  LanguagePlatform current removeGlobalNamed: globalName ifAbsent: [ self fail ].
+
+  sentinel := Object new.
+  self
+    assert: ( LanguagePlatform current globalNamed: globalName ifAbsent: [ sentinel ] )
+    identicalTo: sentinel
+]
+
+{ #category : 'tests' }
 LanguagePlatformTest >> testGlobalNamedIfPresentIfAbsent [
 
 	| sentinel |
@@ -160,4 +181,15 @@ LanguagePlatformTest >> testOSLineEnding [
 	self
 		assert: LanguagePlatform current os lineEnding
 		equals: '<n>' expandMacros
+]
+
+{ #category : 'tests' }
+LanguagePlatformTest >> testRemoveGlobalNamedIfAbsent [
+
+  | wasFound |
+  wasFound := true.
+  LanguagePlatform current
+    removeGlobalNamed: #AnImplausibleGlobalName
+    ifAbsent: [ wasFound := false ].
+  self deny: wasFound
 ]


### PR DESCRIPTION
Adds to `LanguagePlatform`
- `#globalNamed:ifAbsentPut:`
- `#removeGlobalNamed:ifAbsent:`

Also:
- Add icon configuration in dev tools for some classes
- Fix the translation search rule to not fail when it appears on the code critics pane in the System Browser