### PR TITLE
Add Pharo 13

### DIFF
--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -15,6 +15,7 @@ jobs:
           - Pharo64-10
           - Pharo64-11
           - Pharo64-12
+          - Pharo64-13
         load-spec:
           - development
           - dependent-sunit-extensions

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,7 @@ jobs:
           - Pharo64-10
           - Pharo64-11
           - Pharo64-12
+          - Pharo64-13
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 15
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           name: Unit-Tests-${{matrix.smalltalk}}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2024 Gabriel Cotelli, Maximiliano Tabacman and Buenos Aires Smalltalk Contributors
+Copyright (c) 2017-2025 Gabriel Cotelli, Maximiliano Tabacman and Buenos Aires Smalltalk Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ adding useful extensions.
 [![Pharo 10](https://img.shields.io/badge/Pharo-10-informational)](https://pharo.org)
 [![Pharo 11](https://img.shields.io/badge/Pharo-11-informational)](https://pharo.org)
 [![Pharo 12](https://img.shields.io/badge/Pharo-12-informational)](https://pharo.org)
+[![Pharo 13](https://img.shields.io/badge/Pharo-13-informational)](https://pharo.org)
 
 [![GS64 3.7.0](https://img.shields.io/badge/GS64-3.7.0-informational)](https://gemtalksystems.com/products/gs64/)
 [![GS64 3.7.1](https://img.shields.io/badge/GS64-3.7.1-informational)](https://gemtalksystems.com/products/gs64/)

--- a/source/BaselineOfBuoy/BaselineOfBuoy.class.st
+++ b/source/BaselineOfBuoy/BaselineOfBuoy.class.st
@@ -33,17 +33,15 @@ BaselineOfBuoy >> baseline: spec [
         group: 'default' with: 'Development'
     ].
   spec for: #'pharo12.x' do: [
-      self setUpDependencies: spec.
       spec
         package: 'Buoy-Development-Tools-Pharo-12'
-        with: [ spec requires: #( 'Buoy-Development-Tools' 'NeoJSON-Deployment' ) ];
+        with: [ spec requires: 'Buoy-Development-Tools' ];
         group: 'Tools' with: 'Buoy-Development-Tools-Pharo-12'
     ].
   spec for: #'pharo13.x' do: [
-      self setUpDependencies: spec.
       spec
         package: 'Buoy-Development-Tools-Pharo-13'
-        with: [ spec requires: #( 'Buoy-Development-Tools' 'NeoJSON-Deployment' ) ];
+        with: [ spec requires: 'Buoy-Development-Tools' ];
         group: 'Tools' with: 'Buoy-Development-Tools-Pharo-13'
     ]
 ]
@@ -263,12 +261,4 @@ BaselineOfBuoy >> baselineTools: spec [
 BaselineOfBuoy >> projectClass [
 
 	^ MetacelloCypressBaselineProject
-]
-
-{ #category : 'initialization' }
-BaselineOfBuoy >> setUpDependencies: spec [
-
-  spec
-    baseline: 'NeoJSON' with: [ spec repository: 'github://ba-st-dependencies/NeoJSON:v20' ];
-    project: 'NeoJSON-Deployment' copyFrom: 'NeoJSON' with: [ spec loads: 'Deployment' ]
 ]

--- a/source/BaselineOfBuoy/BaselineOfBuoy.class.st
+++ b/source/BaselineOfBuoy/BaselineOfBuoy.class.st
@@ -11,35 +11,41 @@ Class {
 { #category : 'baselines' }
 BaselineOfBuoy >> baseline: spec [
 
-	<baseline>
-	spec
-		for: #pharo
-		do: [ self
-				baselineAssertions: spec;
-				baselineChronology: spec;
-				baselineCollections: spec;
-				baselineConditions: spec;
-				baselineComparison: spec;
-				baselineDynamicBinding: spec;
-				baselineExceptionHandling: spec;
-				baselineLocalization: spec;
-				baselineMath: spec;
-				baselineMetaprogramming: spec;
-				baselineSUnit: spec;
-				baselineTools: spec;
-				baselineGS64Development: spec.
-			spec
-				group: 'CI' with: 'Tests';
-				group: 'Development' with: #('Tools' 'Tests');
-				group: 'default' with: 'Development'
-			].
-	spec for: #'pharo12.x' do: [
-		spec
-			package: 'Buoy-Development-Tools-Pharo-12'
-				with: [ spec requires: 'Buoy-Development-Tools' ];
-			group: 'Tools' with: 'Buoy-Development-Tools-Pharo-12'
-	]
-			
+  <baseline>
+  spec for: #pharo do: [
+      self
+        baselineAssertions: spec;
+        baselineChronology: spec;
+        baselineCollections: spec;
+        baselineConditions: spec;
+        baselineComparison: spec;
+        baselineDynamicBinding: spec;
+        baselineExceptionHandling: spec;
+        baselineLocalization: spec;
+        baselineMath: spec;
+        baselineMetaprogramming: spec;
+        baselineSUnit: spec;
+        baselineTools: spec;
+        baselineGS64Development: spec.
+      spec
+        group: 'CI' with: 'Tests';
+        group: 'Development' with: #( 'Tools' 'Tests' );
+        group: 'default' with: 'Development'
+    ].
+  spec for: #'pharo12.x' do: [
+      self setUpDependencies: spec.
+      spec
+        package: 'Buoy-Development-Tools-Pharo-12'
+        with: [ spec requires: #( 'Buoy-Development-Tools' 'NeoJSON-Deployment' ) ];
+        group: 'Tools' with: 'Buoy-Development-Tools-Pharo-12'
+    ].
+  spec for: #'pharo13.x' do: [
+      self setUpDependencies: spec.
+      spec
+        package: 'Buoy-Development-Tools-Pharo-13'
+        with: [ spec requires: #( 'Buoy-Development-Tools' 'NeoJSON-Deployment' ) ];
+        group: 'Tools' with: 'Buoy-Development-Tools-Pharo-13'
+    ]
 ]
 
 { #category : 'baselines' }
@@ -257,4 +263,12 @@ BaselineOfBuoy >> baselineTools: spec [
 BaselineOfBuoy >> projectClass [
 
 	^ MetacelloCypressBaselineProject
+]
+
+{ #category : 'initialization' }
+BaselineOfBuoy >> setUpDependencies: spec [
+
+  spec
+    baseline: 'NeoJSON' with: [ spec repository: 'github://ba-st-dependencies/NeoJSON:v20' ];
+    project: 'NeoJSON-Deployment' copyFrom: 'NeoJSON' with: [ spec loads: 'Deployment' ]
 ]

--- a/source/Buoy-Development-Tools-Pharo-12/NaturalLanguageTranslationScanner.class.st
+++ b/source/Buoy-Development-Tools-Pharo-12/NaturalLanguageTranslationScanner.class.st
@@ -42,11 +42,11 @@ NaturalLanguageTranslationScanner >> exportOn: writeStream [
   stringsToTranslate do: [ :string |
       translations at: ( translator hashCodeFor: string ) hex put: string ].
 
-  ( NeoJSONWriter on: writeStream )
-    prettyPrint: true;
-    nextPut: ( OrderedDictionary new
+  STONJSON
+    put: ( OrderedDictionary new
           at: self projectName put: translations;
-          yourself ).
+          yourself )
+    onStreamPretty: writeStream.
   writeStream lf
 ]
 

--- a/source/Buoy-Development-Tools-Pharo-13/CircularIterator.extension.st
+++ b/source/Buoy-Development-Tools-Pharo-13/CircularIterator.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'CircularIterator' }
+
+{ #category : '*Buoy-Development-Tools-Pharo-13' }
+CircularIterator class >> systemIconName [
+
+  ^ #collection
+]

--- a/source/Buoy-Development-Tools-Pharo-13/Formatter.extension.st
+++ b/source/Buoy-Development-Tools-Pharo-13/Formatter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'Formatter' }
+
+{ #category : '*Buoy-Development-Tools-Pharo-13' }
+Formatter class >> systemIconName [
+
+  ^ #string
+]

--- a/source/Buoy-Development-Tools-Pharo-13/NaturalLanguageTranslationScanner.class.st
+++ b/source/Buoy-Development-Tools-Pharo-13/NaturalLanguageTranslationScanner.class.st
@@ -1,0 +1,95 @@
+"
+I'm a tool scanning the source code of a project to detect senders of the localization messages to string literals,
+so they can be exported and later translated.
+
+Use me with:
+```smalltalk
+(NaturalLanguageTranslationScanner forProjectNamed: 'ProjectName') export
+```
+"
+Class {
+	#name : 'NaturalLanguageTranslationScanner',
+	#superclass : 'Object',
+	#instVars : [
+		'targetRepository',
+		'environment'
+	],
+	#category : 'Buoy-Development-Tools-Pharo-13',
+	#package : 'Buoy-Development-Tools-Pharo-13'
+}
+
+{ #category : 'examples' }
+NaturalLanguageTranslationScanner class >> example [
+
+  <ignoreForCoverage>
+  <example>
+  ^ ( self forProjectNamed: 'Buoy' ) export
+]
+
+{ #category : 'instance creation' }
+NaturalLanguageTranslationScanner class >> forProjectNamed: aProjectName [
+
+  ^ self new initializeForProjectNamed: aProjectName
+]
+
+{ #category : 'exporting' }
+NaturalLanguageTranslationScanner >> export [
+
+  ^ self exportTo: targetRepository repositoryDirectory / 'locales' / 'en'
+      / ( '<1s>.json' expandMacrosWith: self projectName asLowercase )
+]
+
+{ #category : 'exporting' }
+NaturalLanguageTranslationScanner >> exportOn: writeStream [
+
+  | stringsToTranslate translator translations |
+  stringsToTranslate := SortedCollection new.
+  self scanProjectMethodsCollectingTranslationsIn: stringsToTranslate.
+  translator := MonoglotNaturalLanguageTranslator for: 'en' asLanguageRange.
+  translations := OrderedDictionary new.
+  stringsToTranslate do: [ :string |
+      translations at: ( translator hashCodeFor: string ) hex put: string ].
+
+  ( NeoJSONWriter on: writeStream )
+    prettyPrint: true;
+    nextPut: ( OrderedDictionary new
+          at: self projectName put: translations;
+          yourself ).
+  writeStream lf
+]
+
+{ #category : 'exporting' }
+NaturalLanguageTranslationScanner >> exportTo: targetFileReference [
+
+  targetFileReference
+    ensureCreateFile;
+    writeStreamDo: [ :stream | self exportOn: stream ]
+]
+
+{ #category : 'initialization' }
+NaturalLanguageTranslationScanner >> initializeForProjectNamed: aProjectName [
+
+  targetRepository := IceRepository registry
+                        detect: [ :repository | repository name = aProjectName ]
+                        ifNone: [
+                            ObjectNotFound signal:
+                              ( 'Missing repository for project named <1s>' expandMacrosWith:
+                                  aProjectName )
+                          ].
+  environment := RBBrowserEnvironment new forPackageNames:
+                   ( targetRepository project packageNames select: [ :name |
+                         PackageOrganizer default hasPackage: name ] )
+]
+
+{ #category : 'accessing' }
+NaturalLanguageTranslationScanner >> projectName [
+
+  ^ targetRepository name
+]
+
+{ #category : 'private' }
+NaturalLanguageTranslationScanner >> scanProjectMethodsCollectingTranslationsIn: stringsToTranslate [
+
+  ( SearchMethodsForLocalizationMessagesRule collectingTranslationsIn: stringsToTranslate )
+    runOnEnvironment: environment
+]

--- a/source/Buoy-Development-Tools-Pharo-13/NaturalLanguageTranslationScanner.class.st
+++ b/source/Buoy-Development-Tools-Pharo-13/NaturalLanguageTranslationScanner.class.st
@@ -50,11 +50,11 @@ NaturalLanguageTranslationScanner >> exportOn: writeStream [
   stringsToTranslate do: [ :string |
       translations at: ( translator hashCodeFor: string ) hex put: string ].
 
-  ( NeoJSONWriter on: writeStream )
-    prettyPrint: true;
-    nextPut: ( OrderedDictionary new
+  STONJSON
+    put: ( OrderedDictionary new
           at: self projectName put: translations;
-          yourself ).
+          yourself )
+    onStreamPretty: writeStream.
   writeStream lf
 ]
 

--- a/source/Buoy-Development-Tools-Pharo-13/OCProgramNode.extension.st
+++ b/source/Buoy-Development-Tools-Pharo-13/OCProgramNode.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'OCProgramNode' }
+
+{ #category : '*Buoy-Development-Tools-Pharo-13' }
+OCProgramNode class >> formatters [
+
+	^ (RBAbstractFormatter allSubclasses reject: [ :each | each isAbstract ])
+			sort: [ :a :b | a priority > b priority ]
+]

--- a/source/Buoy-Development-Tools-Pharo-13/SearchMethodsForLocalizationMessagesRule.class.st
+++ b/source/Buoy-Development-Tools-Pharo-13/SearchMethodsForLocalizationMessagesRule.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'SearchMethodsForLocalizationMessagesRule',
+	#superclass : 'RBParseTreeLintRule',
+	#instVars : [
+		'stringsToTranslate'
+	],
+	#category : 'Buoy-Development-Tools-Pharo-13',
+	#package : 'Buoy-Development-Tools-Pharo-13'
+}
+
+{ #category : 'instance creation' }
+SearchMethodsForLocalizationMessagesRule class >> collectingTranslationsIn: aCollection [
+
+  ^ self new initializeCollectingTranslationsIn: aCollection
+]
+
+{ #category : 'testing' }
+SearchMethodsForLocalizationMessagesRule class >> isVisible [
+
+  ^ false
+]
+
+{ #category : 'initialization' }
+SearchMethodsForLocalizationMessagesRule >> initialize [
+
+  super initialize.
+  stringsToTranslate := OrderedCollection new.
+  matcher
+    matches: '`#string localized'
+    do: [ :node :answer | stringsToTranslate add: node receiver value ];
+    matches: '`#string localizedWithAll: `@values'
+    do: [ :node :answer | stringsToTranslate add: node receiver value ]
+]
+
+{ #category : 'initialization' }
+SearchMethodsForLocalizationMessagesRule >> initializeCollectingTranslationsIn: aCollection [
+
+  stringsToTranslate := aCollection
+]
+
+{ #category : 'accessing' }
+SearchMethodsForLocalizationMessagesRule >> name [
+
+  ^ 'Search methods for localization messages'
+]

--- a/source/Buoy-Development-Tools-Pharo-13/TonelWriterV3.extension.st
+++ b/source/Buoy-Development-Tools-Pharo-13/TonelWriterV3.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : 'TonelWriterV3' }
+
+{ #category : '*Buoy-Development-Tools-Pharo-13' }
+TonelWriterV3 >> typeClassDefinitionOf: aClassDefinition [
+
+	| definition |
+	definition := OrderedDictionary new.
+	self
+		at: #name put: aClassDefinition className in: definition;
+		at: #superclass put: aClassDefinition superclassName in: definition.
+	aClassDefinition type = #normal ifFalse: [ self at: #type put: aClassDefinition type in: definition ].
+	aClassDefinition hasTraitComposition ifTrue: [ definition at: #traits put: aClassDefinition traitCompositionString ].
+	aClassDefinition hasClassTraitComposition ifTrue: [ definition at: #classTraits put: aClassDefinition classTraitCompositionString ].
+	aClassDefinition instVarNames ifNotEmpty: [ :vars | definition at: #instVars put: vars asArray ].
+	(aClassDefinition variables
+		 select: #isClassVariable
+		 thenCollect: #name) ifNotEmpty: [ :vars | definition at: #classVars put: vars asArray ].
+	(aClassDefinition variables
+		 select: #isPoolImport
+		 thenCollect: #name) ifNotEmpty: [ :vars | definition at: #pools put: vars asArray ].
+	aClassDefinition classInstVarNames ifNotEmpty: [ :vars | definition at: #classInstVars put: vars asArray ].
+	self setPackageInfoOf: aClassDefinition in: definition.
+	"Write gs_options if available as class properties"
+	(aClassDefinition actualClass ifNotNil:[:actualClass | (actualClass  propertyAt: #gs_options) ifNotNil: [ :options | definition at: #gs_options put: options ]]).
+	^ self toSTON: definition
+]

--- a/source/Buoy-Development-Tools-Pharo-13/package.st
+++ b/source/Buoy-Development-Tools-Pharo-13/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Buoy-Development-Tools-Pharo-13' }

--- a/source/Buoy-Development-Tools/BuenosAiresSmalltalkFormatter.class.st
+++ b/source/Buoy-Development-Tools/BuenosAiresSmalltalkFormatter.class.st
@@ -158,3 +158,16 @@ BuenosAiresSmalltalkFormatter >> formatBlock: aBlockNode [
     ifTrue: [ self newLine ]
     ifFalse: [ codeStream nextPutAll: self spacesInsideBlocksString ]
 ]
+
+{ #category : 'private' }
+BuenosAiresSmalltalkFormatter >> needsParenthesisFor: aNode [
+
+  | parent |
+  aNode ifNil: [ ^ false ].
+  aNode isValue ifFalse: [ ^ false ].
+  aNode isParseError ifTrue: [ ^ aNode hasParentheses ].
+  parent := aNode parent ifNil: [ ^ false ].
+  ^ parent isDynamicArray
+      ifTrue: [ false ]
+      ifFalse: [ super needsParenthesisFor: aNode ]
+]

--- a/source/Buoy-Math-GS64-Base-Extensions/BinaryFloat.extension.st
+++ b/source/Buoy-Math-GS64-Base-Extensions/BinaryFloat.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'BinaryFloat' }
 BinaryFloat >> closeTo: num [
 	"Tell whether the receiver and arguments are close from each."
 
-	^ self closeTo: num precision: 0.0001
+	^ self closeTo: num precision: self class defaultComparisonPrecision
 ]
 
 { #category : '*Buoy-Math-GS64-Base-Extensions' }
@@ -14,6 +14,15 @@ BinaryFloat >> closeTo: num precision: aPrecision [
 	num isNumber ifFalse: [ ^ false ].
 
 	^ self = num asFloat or: [ (self - num) abs <= aPrecision ]
+]
+
+{ #category : '*Buoy-Math-GS64-Base-Extensions' }
+BinaryFloat class >> defaultComparisonPrecision [
+
+	"Default precision used for comparing two float numbers.
+	Using value described in Numerical Recipes, 3rd edition, Section 5.7, which is pages 229-230
+	corresponding to the square root of the machine epsilon: self epsilon sqrt"
+	^ 1.4901161193847656e-8
 ]
 
 { #category : '*Buoy-Math-GS64-Base-Extensions' }

--- a/source/Buoy-Math-GS64-Base-Extensions/Number.extension.st
+++ b/source/Buoy-Math-GS64-Base-Extensions/Number.extension.st
@@ -14,6 +14,12 @@ Number >> closeTo: num [
 ]
 
 { #category : '*Buoy-Math-GS64-Base-Extensions' }
+Number >> closeTo: number precision: precision [
+
+	^ number closeTo: self asFloat precision: precision
+]
+
+{ #category : '*Buoy-Math-GS64-Base-Extensions' }
 Number >> isInteger [
 
 	^ false

--- a/source/Buoy-Math-Tests/BuoyNumberExtensionsTest.class.st
+++ b/source/Buoy-Math-Tests/BuoyNumberExtensionsTest.class.st
@@ -22,16 +22,16 @@ BuoyNumberExtensionsTest >> testAsHexStringPaddedTo [
 { #category : 'tests' }
 BuoyNumberExtensionsTest >> testCloseTo [
 
-	self assert: (3 closeTo: 3.00001).
-	self assert: (0 closeTo: 0.00001).
-	self deny: (3.3345 closeTo: 3.335).
+  self assert: ( 3 closeTo: 3.00001 precision: 0.0001 ).
+  self assert: ( 0 closeTo: 0.00001 precision: 0.0001 ).
+  self deny: ( 3.3345 closeTo: 3.335 precision: 0.0001 ).
 
-	self deny: (-1.0 closeTo: 1.0).
+  self deny: ( -1.0 closeTo: 1.0 ).
 
-	self assert: (1.0 / 3.0 closeTo: 1 / 3).
-	self assert: (1.0e-8 closeTo: 0).
-	self assert: (0 closeTo: 1.0e-8).
-	self assert: (1 + 1.0e-8 closeTo: 1.0)
+  self assert: ( 1.0 / 3.0 closeTo: 1 / 3 ).
+  self assert: ( 1.0e-8 closeTo: 0 ).
+  self assert: ( 0 closeTo: 1.0e-8 ).
+  self assert: ( 1 + 1.0e-8 closeTo: 1.0 )
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
- Add Pharo 13 as a supported platform
- Update some dev tools to not depend on NeoJSON and use STONJSON instead that's available in the base Pharo image
- Change `BinaryFloat>>closeTo:` in GS64 to match the behavior of Pharo 13 that departs from the previous versions. Now the default comparison precision is the square root of `Float epsilon`. This change **breaks the backward compatibility** with previous versions.
- Update codecov action to v5
- Fixed formatter to avoid unnecessary parentheses inside dynamic arrays