### PR TITLE
Improve initialization to better handle Rowan loading issues in dependent projects

### DIFF
--- a/source/Buoy-Localization-GS64-Extensions/NaturalLanguageTranslator.class.st
+++ b/source/Buoy-Localization-GS64-Extensions/NaturalLanguageTranslator.class.st
@@ -14,9 +14,10 @@ Class {
 
 { #category : 'accessing' }
 NaturalLanguageTranslator class >> current [
-	"Return the currently registered translator"
+  "Return the currently registered translator"
 
-	^Current
+  Current ifNil: [ self current: PolyglotNaturalLanguageTranslator new ].
+  ^ Current
 ]
 
 { #category : 'accessing' }

--- a/source/Buoy-Localization/EscapingAlgorithm.class.st
+++ b/source/Buoy-Localization/EscapingAlgorithm.class.st
@@ -18,6 +18,7 @@ EscapingAlgorithm class >> initialize [
 { #category : 'instance creation' }
 EscapingAlgorithm class >> new [
 
+  UniqueInstace ifNil: [ self initialize ].
   ^ UniqueInstace
 ]
 

--- a/source/Buoy-Math/Percentage.class.st
+++ b/source/Buoy-Math/Percentage.class.st
@@ -18,23 +18,25 @@ Percentage class >> fraction [
 	^ 100
 ]
 
-{ #category : 'initialization' }
+{ #category : 'class initialization' }
 Percentage class >> initialize [
 	<ignoreForCoverage>
 	oneHundredPercent := self ratio: 1.
 	zeroPercent := self ratio: 0
 ]
 
-{ #category : 'Instance Creation' }
+{ #category : 'instance creation' }
 Percentage class >> oneHundred [
 
-	^ oneHundredPercent
+  oneHundredPercent ifNil: [ self initialize ].
+  ^ oneHundredPercent
 ]
 
-{ #category : 'Instance Creation' }
+{ #category : 'instance creation' }
 Percentage class >> zero [
-	
-	^zeroPercent 
+
+  zeroPercent ifNil: [ self initialize ].
+  ^ zeroPercent
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
When loading a project that has Buoy as a dependency in GS64, the order in which the class `initialize` methods are called is not necessarily the same as the package loading order in Pharo. This has some funny consequences, so we are being conservative here and call initialize if trying to access the uninitialized state.