### PR TITLE
Add BaselineOf facilities

### DIFF
--- a/source/BaselineOfBuoy/BaselineOfBuoy.class.st
+++ b/source/BaselineOfBuoy/BaselineOfBuoy.class.st
@@ -221,20 +221,25 @@ BaselineOfBuoy >> baselineMath: spec [
 { #category : 'baselines' }
 BaselineOfBuoy >> baselineMetaprogramming: spec [
 
-	spec
-		package: 'Buoy-Metaprogramming'
-		with: [ spec requires: 'Buoy-Assertions' ];
-		group: 'Deployment' with: 'Buoy-Metaprogramming';
-		package: 'Buoy-Metaprogramming-Extensions'
-		with: [ spec requires: 'Buoy-Assertions' ];
-		group: 'Deployment' with: 'Buoy-Metaprogramming-Extensions';
-		package: 'Buoy-Metaprogramming-Pharo-Extensions';
-		group: 'Deployment' with: 'Buoy-Metaprogramming-Pharo-Extensions';
-		package: 'Buoy-Metaprogramming-Tests' with: [
-			spec requires:
-					#( 'Buoy-Metaprogramming' 'Buoy-Metaprogramming-Extensions'
-					   'Buoy-Metaprogramming-Pharo-Extensions' ) ];
-		group: 'Tests' with: 'Buoy-Metaprogramming-Tests'
+  spec
+    package: 'Buoy-Metaprogramming' with: [ spec requires: 'Buoy-Assertions' ];
+    group: 'Deployment' with: 'Buoy-Metaprogramming';
+    package: 'Buoy-Metaprogramming-Extensions' with: [ spec requires: 'Buoy-Assertions' ];
+    group: 'Deployment' with: 'Buoy-Metaprogramming-Extensions';
+    package: 'Buoy-Metaprogramming-Pharo-Extensions';
+    group: 'Deployment' with: 'Buoy-Metaprogramming-Pharo-Extensions';
+    package: 'Buoy-Metaprogramming-Tests' with: [
+        spec requires:
+            #( 'Buoy-Metaprogramming' 'Buoy-Metaprogramming-Extensions'
+               'Buoy-Metaprogramming-Pharo-Extensions' )
+      ];
+    group: 'Tests' with: 'Buoy-Metaprogramming-Tests'.
+
+  spec for: #( #'pharo10.x' #'pharo11.x' #'pharo12.x' ) do: [
+      spec
+        package: 'Buoy-Metaprogramming-Pharo-10-Extensions';
+        group: 'Deployment' with: 'Buoy-Metaprogramming-Pharo-10-Extensions'
+    ]
 ]
 
 { #category : 'baselines' }

--- a/source/Buoy-Metaprogramming-Pharo-10-Extensions/BaselineOf.extension.st
+++ b/source/Buoy-Metaprogramming-Pharo-10-Extensions/BaselineOf.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : 'BaselineOf' }
+
+{ #category : '*Buoy-Metaprogramming-Pharo-10-Extensions' }
+BaselineOf >> classNamed: aSymbol [
+
+	^ self class environment at: aSymbol asSymbol
+]
+
+{ #category : '*Buoy-Metaprogramming-Pharo-10-Extensions' }
+BaselineOf >> classNamed: aSymbol ifPresent: aBlock [
+
+	^ self class environment at: aSymbol asSymbol ifPresent: aBlock
+]
+
+{ #category : '*Buoy-Metaprogramming-Pharo-10-Extensions' }
+BaselineOf >> classNamed: aSymbol ifPresent: aBlock ifAbsent: absentBlock [
+
+	^ self class environment at: aSymbol asSymbol ifPresent: aBlock ifAbsent: absentBlock
+]

--- a/source/Buoy-Metaprogramming-Pharo-10-Extensions/package.st
+++ b/source/Buoy-Metaprogramming-Pharo-10-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Buoy-Metaprogramming-Pharo-10-Extensions' }

--- a/source/Buoy-Metaprogramming-Pharo-Extensions/BaselineOf.extension.st
+++ b/source/Buoy-Metaprogramming-Pharo-Extensions/BaselineOf.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : 'BaselineOf' }
+
+{ #category : '*Buoy-Metaprogramming-Pharo-Extensions' }
+BaselineOf >> withSourceDirectoryReferenceDo: aBlock [
+  "Attempts to identify the local source directory.
+   This approach works across several Pharo versions and supports different loading mechanisms"
+
+  self class environment at: #IceRepository ifPresent: [ :icebergRepository |
+      | sources |
+      sources := icebergRepository registry
+                   detect: [ :repository | repository includesPackageNamed: self class name ]
+                   ifFound: [ :repository | repository project sourceDirectoryReference ]
+                   ifNone: [
+                       | repositoriesSpec repositorySpec |
+                       repositoriesSpec := self project projectPackage repositories.
+                       repositorySpec := repositoriesSpec detect: [ :spec | true ].
+                       ( repositorySpec description withoutPrefix: 'tonel://' ) asFileReference
+                     ].
+      aBlock value: sources
+    ]
+]


### PR DESCRIPTION
- Add facilities to `BaselineOf` to access classes by name, useful in post-load scripts to avoid warnings on not-yet loaded code. Brings Pharo 10 to 12 on par with Pharo 13.
- Add a utility method to `BaselineOf` to locate the source directory in the local filesystem. Useful when loading non-code files in the repo in a post-load script. 